### PR TITLE
fix(sdks/docs): user-feedback fixes — gateway 403 mapping, header-name docs, placeholder URLs

### DIFF
--- a/docs/content/docs/async-client.mdx
+++ b/docs/content/docs/async-client.mdx
@@ -13,12 +13,13 @@ This page is **Python-specific**. The Node SDK is async-only by design — every
 
 ```python
 import asyncio
+import os
 from memsy import AsyncMemsyClient, EventPayload
 
 async def main():
     async with AsyncMemsyClient(
-        base_url="https://api.memsy.io/v1",
-        api_key="***",
+        base_url=os.environ["MEMSY_BASE_URL"],
+        api_key=os.environ["MEMSY_API_KEY"],
     ) as client:
         health = await client.health()
         print(health.status)

--- a/docs/content/docs/ingesting-events.mdx
+++ b/docs/content/docs/ingesting-events.mdx
@@ -5,6 +5,10 @@ description: Batch size, metadata, timestamps, scoping — everything beyond the
 
 `ingest()` takes a list of events and returns their IDs.
 
+<Note>
+**Field naming.** The JSON wire format uses `snake_case` (`actor_id`, `session_id`, `role_id`, `team_id`). The **Python SDK** accepts `snake_case`. The **Node SDK** accepts `camelCase` (`actorId`, `sessionId`, …) and converts on send. Don't mix conventions across SDKs — pasting `actor_id` into a Node call (or `actorId` into the cURL body) returns `422`.
+</Note>
+
 ## Role and team scoping
 
 This is what sets Memsy apart: every event can be scoped to a role and team in your [onboarding hierarchy](/docs/onboarding). Extracted memories are stored at the right level of your org — not just a flat blob per user — so searches respect organizational context automatically.

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -198,7 +198,7 @@ In three calls you:
 
 And as a bonus:
 
-- Every response has `usage` and `rateLimit`/`rate_limit` populated from response headers — you already know how much of your plan you've used.
+- Every response has `usage` populated from `X-Usage-*` response headers — you already know how much of your plan you've used. `rateLimit` / `rate_limit` is populated from `X-RateLimit-*` headers when the server returns them.
 - Rate-limited calls (HTTP 429) are retried automatically with exponential backoff. No code to write.
 - HTTP errors come back as typed exceptions in both SDKs (`AuthenticationError`/`MemsyAuthError`, `UsageLimitExceeded`, `MemsyRateLimitError`, …).
 

--- a/docs/content/docs/reference/node/control-client.mdx
+++ b/docs/content/docs/reference/node/control-client.mdx
@@ -9,8 +9,8 @@ description: The Node.js MemsyControlClient — control-plane endpoints (api/) f
 import { MemsyControlClient } from '@memsy-io/memsy';
 
 const control = new MemsyControlClient({
-  baseUrl: 'https://api.memsy.io/api',
-  apiKey: 'msy_...',
+  baseUrl: process.env.MEMSY_CONTROL_URL!,
+  apiKey: process.env.MEMSY_API_KEY!,
 });
 ```
 

--- a/docs/content/docs/reference/node/resources.mdx
+++ b/docs/content/docs/reference/node/resources.mdx
@@ -8,7 +8,10 @@ description: orgs, roles, teams, and memories — sub-resources on the Node Mems
 ```ts
 import { MemsyClient } from '@memsy-io/memsy';
 
-const client = new MemsyClient({ baseUrl: 'https://api.memsy.io/v1', apiKey: 'msy_...' });
+const client = new MemsyClient({
+  baseUrl: process.env.MEMSY_BASE_URL!,
+  apiKey: process.env.MEMSY_API_KEY!,
+});
 
 client.orgs;       // OrgsResource
 client.roles;      // RolesResource

--- a/docs/content/docs/reference/python/control-client.mdx
+++ b/docs/content/docs/reference/python/control-client.mdx
@@ -44,7 +44,12 @@ MemsyControlClient(
 ## Context manager
 
 ```python
-with MemsyControlClient(base_url="https://api.memsy.io/api", api_key="msy_...") as control:
+import os
+
+with MemsyControlClient(
+    base_url=os.environ["MEMSY_CONTROL_URL"],
+    api_key=os.environ["MEMSY_API_KEY"],
+) as control:
     me = control.me()
 ```
 
@@ -167,9 +172,11 @@ already_expressed: bool = control.interest.status()
 `AsyncMemsyControlClient` is the async counterpart. Every method is identical but returns a coroutine.
 
 ```python
+import os
+
 async with AsyncMemsyControlClient(
-    base_url="https://api.memsy.io/api",
-    api_key="msy_...",
+    base_url=os.environ["MEMSY_CONTROL_URL"],
+    api_key=os.environ["MEMSY_API_KEY"],
 ) as control:
     me = await control.me()
     summary = await control.usage.summary()

--- a/docs/content/docs/retries.mdx
+++ b/docs/content/docs/retries.mdx
@@ -22,11 +22,12 @@ The SDK retries rate-limited (HTTP 429) requests automatically. Everything else 
 <Tabs>
   <Tab title="Python">
     ```python
+    import os
     from memsy import MemsyClient
 
     client = MemsyClient(
-        base_url="https://api.memsy.io/v1",
-        api_key="***",
+        base_url=os.environ["MEMSY_BASE_URL"],
+        api_key=os.environ["MEMSY_API_KEY"],
         max_retries=5,       # try up to 5 times on 429 (default: 3)
         retry_backoff=2.0,   # base backoff, doubles per attempt (default: 1.0)
         timeout=60.0,        # per-request timeout in seconds (default: 30.0)
@@ -38,8 +39,8 @@ The SDK retries rate-limited (HTTP 429) requests automatically. Everything else 
     import { MemsyClient } from '@memsy-io/memsy';
 
     const client = new MemsyClient({
-      baseUrl: 'https://api.memsy.io/v1',
-      apiKey: '***',
+      baseUrl: process.env.MEMSY_BASE_URL!,
+      apiKey: process.env.MEMSY_API_KEY!,
       maxRetries: 5,        // try up to 5 times on 429 (default: 3)
       timeoutMs: 60_000,    // per-request timeout in ms (default: 30_000)
     });

--- a/docs/content/docs/usage-and-rate-limits.mdx
+++ b/docs/content/docs/usage-and-rate-limits.mdx
@@ -44,8 +44,8 @@ Both may be `None` / `null` if the server didn't return the corresponding header
       -d '{"query": "preferences"}' \
       | grep -E "^X-(Usage|Plan|RateLimit)-"
     # X-Plan: pro
-    # X-Usage-ApiCall: 1042
-    # X-Usage-ApiCall-Limit: 100000
+    # X-Usage-ApiCalls: 1042
+    # X-Usage-ApiCalls-Limit: 100000
     # ...
     ```
   </Tab>
@@ -107,12 +107,12 @@ Fields on `RateLimitInfo`:
 
 | Header | Field |
 |---|---|
-| `X-Usage-ApiCall` | `usage.api_calls` |
-| `X-Usage-ApiCall-Limit` | `usage.api_calls_limit` |
+| `X-Usage-ApiCalls` | `usage.api_calls` |
+| `X-Usage-ApiCalls-Limit` | `usage.api_calls_limit` |
 | `X-Usage-EventsIngested` | `usage.events_ingested` |
 | `X-Usage-EventsIngested-Limit` | `usage.events_ingested_limit` |
-| `X-Usage-MemoryStored` | `usage.memory_stored` |
-| `X-Usage-MemoryStored-Limit` | `usage.memory_stored_limit` |
+| `X-Usage-MemoriesStored` | `usage.memory_stored` |
+| `X-Usage-MemoriesStored-Limit` | `usage.memory_stored_limit` |
 | `X-Usage-LlmTokens` | `usage.llm_tokens` |
 | `X-Usage-LlmTokens-Limit` | `usage.llm_tokens_limit` |
 | `X-Usage-SearchQueries` | `usage.search_queries` |

--- a/sdks/node/scripts/e2e.mjs
+++ b/sdks/node/scripts/e2e.mjs
@@ -3,7 +3,7 @@
  * End-to-end smoke test for @memsy-io/memsy against a live Memsy API.
  *
  * Usage:
- *   MEMSY_BASE_URL=https://api-dev.memsy.io/v1 \
+ *   MEMSY_BASE_URL=https://api.memsy.io/v1 \
  *   MEMSY_API_KEY=msy_xxx \
  *   node sdks/node/scripts/e2e.mjs
  *

--- a/sdks/node/src/errors.ts
+++ b/sdks/node/src/errors.ts
@@ -278,6 +278,17 @@ export async function classifyError(response: Response): Promise<MemsyAPIError> 
   }
 
   if (status === 403) {
+    // AWS API Gateway HTTP API v2 returns 403 with body {"message":"Forbidden"}
+    // when the Lambda authorizer denies — semantically that's an auth failure
+    // (invalid/revoked/missing key), not a scope or permission problem. Map it
+    // to MemsyAuthError so `instanceof MemsyAuthError` behaves correctly.
+    if (
+      errorCode === null &&
+      Object.keys(body).length === 1 &&
+      body.message === "Forbidden"
+    ) {
+      return new MemsyAuthError(detail, base);
+    }
     if (errorCode === "feature_not_available") {
       return new MemsyFeatureNotAvailableError(detail, {
         ...base,

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -13,9 +13,13 @@ pip install memsy
 ## Quick Start
 
 ```python
+import os
 from memsy import MemsyClient, EventPayload
 
-client = MemsyClient(base_url="https://api.memsy.io", api_key="msy_...")
+client = MemsyClient(
+    base_url=os.environ["MEMSY_BASE_URL"],
+    api_key=os.environ["MEMSY_API_KEY"],
+)
 
 # Remember something
 client.ingest([EventPayload(
@@ -43,8 +47,8 @@ The SDK uses Bearer token authentication. Pass your API key when creating the cl
 
 ```python
 client = MemsyClient(
-    base_url="https://api.memsy.io",
-    api_key="msy_...",
+    base_url=os.environ["MEMSY_BASE_URL"],
+    api_key=os.environ["MEMSY_API_KEY"],
 )
 ```
 
@@ -54,8 +58,8 @@ Configure retry behavior for rate-limited requests:
 
 ```python
 client = MemsyClient(
-    api_key="msy_...",
-    base_url="https://api.memsy.io",
+    base_url=os.environ["MEMSY_BASE_URL"],
+    api_key=os.environ["MEMSY_API_KEY"],
     max_retries=3,         # default: 3
     retry_backoff=1.0,     # default: 1.0 seconds
     timeout=30.0,          # default: 30.0 seconds
@@ -240,8 +244,8 @@ usage reporting, and raw event browsing. Use a second client pointed at the cont
 from memsy import MemsyControlClient
 
 control = MemsyControlClient(
-    base_url="https://api.memsy.io/api",  # your control-plane URL
-    api_key="msy_...",
+    base_url=os.environ["MEMSY_CONTROL_URL"],  # e.g. https://api.memsy.io/api
+    api_key=os.environ["MEMSY_API_KEY"],
 )
 ```
 

--- a/sdks/python/memsy/_http.py
+++ b/sdks/python/memsy/_http.py
@@ -94,6 +94,22 @@ class HttpCoreMixin:
             )
 
         if status_code == 403:
+            # AWS API Gateway HTTP API v2 returns 403 with body {"message":"Forbidden"}
+            # when the Lambda authorizer denies — semantically that's an auth failure
+            # (invalid/revoked/missing key), not a scope or permission problem. Map it to
+            # AuthenticationError so callers' except blocks behave correctly.
+            if (
+                error_code is None
+                and len(body) == 1
+                and body.get("message") == "Forbidden"
+            ):
+                return AuthenticationError(
+                    f"Authentication failed: {detail}",
+                    status_code=status_code,
+                    detail=detail,
+                    error_code=error_code,
+                    response=response,
+                )
             if error_code == "feature_not_available":
                 return FeatureNotAvailable(
                     f"Feature not available: {detail}",

--- a/sdks/python/memsy/async_client.py
+++ b/sdks/python/memsy/async_client.py
@@ -29,7 +29,12 @@ class AsyncMemsyClient(HttpCoreMixin):
 
     Usage::
 
-        async with AsyncMemsyClient(base_url="https://your-api-gateway-url", api_key="***") as c:
+        import os
+
+        async with AsyncMemsyClient(
+            base_url=os.environ["MEMSY_BASE_URL"],
+            api_key=os.environ["MEMSY_API_KEY"],
+        ) as client:
             health = await client.health()
 
         # or manage lifecycle manually

--- a/sdks/python/memsy/async_control.py
+++ b/sdks/python/memsy/async_control.py
@@ -25,9 +25,11 @@ class AsyncMemsyControlClient(HttpCoreMixin):
 
     Usage::
 
+        import os
+
         async with AsyncMemsyControlClient(
-            base_url="https://api.memsy.io/api",
-            api_key="msy_...",
+            base_url=os.environ["MEMSY_CONTROL_URL"],
+            api_key=os.environ["MEMSY_API_KEY"],
         ) as control:
             me = await control.me()
             events = await control.events.list(limit=20)

--- a/sdks/python/memsy/client.py
+++ b/sdks/python/memsy/client.py
@@ -29,7 +29,12 @@ class MemsyClient(HttpCoreMixin):
 
     Usage::
 
-        client = MemsyClient(base_url="https://your-api-gateway-url", api_key="***")
+        import os
+
+        client = MemsyClient(
+            base_url=os.environ["MEMSY_BASE_URL"],
+            api_key=os.environ["MEMSY_API_KEY"],
+        )
 
         # or as a context manager
         with MemsyClient(base_url="...", api_key="***") as client:

--- a/sdks/python/memsy/control.py
+++ b/sdks/python/memsy/control.py
@@ -25,9 +25,11 @@ class MemsyControlClient(HttpCoreMixin):
 
     Usage::
 
+        import os
+
         control = MemsyControlClient(
-            base_url="https://api.memsy.io/api",
-            api_key="msy_...",
+            base_url=os.environ["MEMSY_CONTROL_URL"],
+            api_key=os.environ["MEMSY_API_KEY"],
         )
 
         me = control.me()

--- a/sdks/python/scripts/e2e.py
+++ b/sdks/python/scripts/e2e.py
@@ -2,7 +2,7 @@
 """End-to-end smoke test for the memsy Python SDK against a live Memsy API.
 
 Usage:
-    MEMSY_BASE_URL=https://api-dev.memsy.io/v1 \\
+    MEMSY_BASE_URL=https://api.memsy.io/v1 \\
     MEMSY_API_KEY=msy_xxx \\
     python sdks/python/scripts/e2e.py
 

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -222,8 +222,8 @@ class TestUsageHeaders:
         mock_response.is_success = True
         mock_response.json.return_value = {"status": "ok"}
         mock_response.headers = {
-            "X-Usage-ApiCall": "100",
-            "X-Usage-ApiCall-Limit": "500000",
+            "X-Usage-ApiCalls": "100",
+            "X-Usage-ApiCalls-Limit": "500000",
             "X-Plan": "pro",
         }
         mock_request.return_value = mock_response

--- a/sdks/python/tests/test_models.py
+++ b/sdks/python/tests/test_models.py
@@ -482,8 +482,8 @@ class TestUsageInfo:
     def test_from_headers_populated(self):
         u = UsageInfo.from_headers(
             {
-                "X-Usage-ApiCall": "100",
-                "X-Usage-ApiCall-Limit": "50000",
+                "X-Usage-ApiCalls": "100",
+                "X-Usage-ApiCalls-Limit": "50000",
                 "X-Plan": "pro",
             }
         )

--- a/sdks/python/tests/test_usage_headers.py
+++ b/sdks/python/tests/test_usage_headers.py
@@ -21,12 +21,12 @@ class TestUsageInfoParsing:
     def test_parse_all_usage_headers(self):
         """Test parsing all usage headers correctly."""
         headers = {
-            "X-Usage-ApiCall": "100",
-            "X-Usage-ApiCall-Limit": "500000",
+            "X-Usage-ApiCalls": "100",
+            "X-Usage-ApiCalls-Limit": "500000",
             "X-Usage-EventsIngested": "25000",
             "X-Usage-EventsIngested-Limit": "100000",
-            "X-Usage-MemoryStored": "5000",
-            "X-Usage-MemoryStored-Limit": "50000",
+            "X-Usage-MemoriesStored": "5000",
+            "X-Usage-MemoriesStored-Limit": "50000",
             "X-Usage-LlmTokens": "100000",
             "X-Usage-LlmTokens-Limit": "1000000",
             "X-Usage-SearchQueries": "5000",
@@ -51,7 +51,7 @@ class TestUsageInfoParsing:
     def test_parse_partial_usage_headers(self):
         """Test parsing partial usage headers."""
         headers = {
-            "X-Usage-ApiCall": "100",
+            "X-Usage-ApiCalls": "100",
             "X-Plan": "free",
         }
         
@@ -74,8 +74,8 @@ class TestUsageInfoParsing:
     def test_parse_invalid_int_values(self):
         """Test parsing with invalid integer values."""
         headers = {
-            "X-Usage-ApiCall": "not-a-number",
-            "X-Usage-ApiCall-Limit": "500000",
+            "X-Usage-ApiCalls": "not-a-number",
+            "X-Usage-ApiCalls-Limit": "500000",
         }
         
         usage = UsageInfo.from_headers(headers)
@@ -149,8 +149,8 @@ class TestClientResponseHeaders:
         mock_response.is_success = True
         mock_response.json.return_value = {"status": "ok"}
         mock_response.headers = {
-            "X-Usage-ApiCall": "100",
-            "X-Usage-ApiCall-Limit": "500000",
+            "X-Usage-ApiCalls": "100",
+            "X-Usage-ApiCalls-Limit": "500000",
             "X-Plan": "pro",
             "X-RateLimit-Limit": "1000",
             "X-RateLimit-Remaining": "950",
@@ -174,7 +174,7 @@ class TestClientResponseHeaders:
         mock_response.is_success = True
         mock_response.json.return_value = {"status": "ok"}
         mock_response.headers = {
-            "X-Usage-ApiCall": "100",
+            "X-Usage-ApiCalls": "100",
             "X-Plan": "free",
         }
 


### PR DESCRIPTION
## Summary

Fixes from the round of user feedback on the just-shipped multi-SDK docs and 0.1.1 / 0.3.1 SDK releases. All four commits are independently revertable.

## What's in this PR

### 1. `fix: update tests and docs to plural X-Usage-ApiCalls / MemoriesStored headers` (`4848028`)
The earlier commit `60a488d` corrected the SDK to read the plural header names the server emits, but the test fixtures and the `usage-and-rate-limits.mdx` reference table still used the singular form. Without this, `pytest` fails on the usage-header tests and the doc table tells users the wrong header names to grep for.

### 2. `fix(sdks): map gateway 403 {message:Forbidden} to AuthenticationError` (`d6b55b4`)
**Root cause:** AWS API Gateway HTTP API v2 returns `403 {"message":"Forbidden"}` whenever the Lambda authorizer denies a request — there's no clean way in HTTP API v2 to surface a `401` from a denying authorizer. So an invalid API key currently lands as `MemsyAuthorizationError` (semantically "you lack a scope") instead of `MemsyAuthError` (semantically "your key is invalid").

**Fix:** add a defense-in-depth check at the top of the `403` branch in both SDKs' error classifiers. When the body is exactly `{"message":"Forbidden"}` with no `error_code`, classify as `AuthenticationError` / `MemsyAuthError`.

This ships immediately. The proper server-side fix (Lambda authorizer or gateway-response mapping) is planned in the infra repo as a follow-up.

### 3. `docs(sdks): replace placeholder URLs in docstrings/README with env-var pattern` (`9ddc79a`)
The Python SDK shipped with `https://your-api-gateway-url` literally in `client.py` and `async_client.py` docstrings. That string surfaces in IDE help text and on PyPI. Also fixed the README's hardcoded URLs (one was missing `/v1`).

Switched everything to `os.environ["MEMSY_BASE_URL"]` / `process.env.MEMSY_BASE_URL` (and `MEMSY_CONTROL_URL` for control-plane examples). Same pattern in the `e2e` script docstrings.

### 4. `docs: switch instantiation examples to env-var pattern + add snake/camel callout` (`f200faa`)
- All `MemsyClient(...)` / `MemsyControlClient(...)` examples in async-client / quickstart / retries / reference docs now use the env-var pattern.
- New Note on `ingesting-events.mdx`: wire format is snake_case, Python SDK accepts snake_case, Node SDK accepts camelCase. A reader skimming both blocks side-by-side could otherwise paste `actor_id` into a Node call (or `actorId` into curl) and get a 422.
- Softened the quickstart "every response has rateLimit populated" claim — `rateLimit` is populated only when the server returns `X-RateLimit-*` headers.

## Out of scope (separate follow-ups)

- **`X-RateLimit-*` header emission in `memsy-core`** — the planned `UsageHeaderMiddleware` rate-limit emission was never shipped. Add to memsy-core's middleware chain alongside `usage_headers.py`.
- **Lambda authorizer 401 handling in `infra` repo** — long-term replacement for the SDK defense-in-depth above. Either rewrite the authorizer to a JWT authorizer (which gives 401 on token failures), or configure custom gateway response mappings on the API Gateway.
- **Pre-existing 429 retry-exhaustion test failures** — `test_errors.py::TestRateLimitExceeded` and `test_retry.py::TestRetryLogic` fail because the SDK's retry-exhaustion path raises `MemsyAPIError("Max retries exceeded")` instead of `RateLimitExceeded`. Confirmed unrelated to this PR by stashing changes and re-running.

## Test plan

- [x] `pytest` in `sdks/python` — 59 relevant tests pass after the header-name + classification fixes; 5 pre-existing 429 failures unchanged
- [x] `tsc --noEmit` clean in `sdks/node`
- [x] `npm run build` produces clean dist
- [x] No `api-dev` / "preview phase" / "not prod-ready" language anywhere in customer-facing docs or SDK source
- [ ] Manual smoke: run the e2e scripts against the live API after merge to confirm the 403→AuthenticationError mapping works end-to-end with a revoked key