### PR TITLE
docs+sdk: surface tester-bug-fix behaviour changes

### DIFF
--- a/docs/content/docs/async-client.mdx
+++ b/docs/content/docs/async-client.mdx
@@ -38,10 +38,17 @@ await client.ingest([...])
 await client.search("query", actor_id="user_42")
 await client.status(event_ids=[...])
 await client.health()
-await client.clear("container_tag")
+await client.clear("container_tag")  # currently a 501 stub — see note below
 ```
 
 All parameter names, defaults, return types, and exceptions match the sync client.
+
+<Callout type="warn">
+  `clear()` currently returns `501 Not Implemented` and raises
+  `MemsyAPIError` — the underlying server-side delete is not yet wired up.
+  Avoid calling it in production paths; everything else on the async client
+  is fully functional.
+</Callout>
 
 ## Parallel calls
 

--- a/docs/content/docs/async-client.mdx
+++ b/docs/content/docs/async-client.mdx
@@ -43,12 +43,12 @@ await client.clear("container_tag")  # currently a 501 stub — see note below
 
 All parameter names, defaults, return types, and exceptions match the sync client.
 
-<Callout type="warn">
+<Warning>
   `clear()` currently returns `501 Not Implemented` and raises
   `MemsyAPIError` — the underlying server-side delete is not yet wired up.
   Avoid calling it in production paths; everything else on the async client
   is fully functional.
-</Callout>
+</Warning>
 
 ## Parallel calls
 

--- a/docs/content/docs/async-processing.mdx
+++ b/docs/content/docs/async-processing.mdx
@@ -117,7 +117,7 @@ Failures are rare but not zero. Check `failed_ids` in your pollers if correctnes
 **Don't block your request pipeline on `status()`.** Use it only when your next action requires the memory to be present.
 </Warning>
 
-- **Don't re-ingest the same event to "retry".** Memsy de-duplicates ingestion by content hash within a short window; re-sending can create noise.
+- **Re-ingesting an event is safe within a 60-second window** — Memsy de-duplicates by `(actor_id, session_id, kind, content)` and returns the original `event_id` so `status()` keeps working. Outside the window, identical payloads will create separate events; use `status()` to confirm processing instead of re-sending.
 - **Do batch aggressively.** `ingest()` accepts many events per call; fifty events in one batch is much cheaper than fifty single-event calls.
 
 ## Next

--- a/docs/content/docs/console-memories.mdx
+++ b/docs/content/docs/console-memories.mdx
@@ -28,6 +28,7 @@ description: Browse and inspect stored memories via client.memories.
   <Tab title="Python">
     ```python
     result = client.memories.list(
+        actor_id="user_42",     # optional: filter to a single actor's memories
         kind="semantic",        # optional: "semantic" | "episodic" | ...
         type="preference",      # optional: "preference" | "fact" | "event" | ...
         status="active",        # optional: "active" | "archived" | "decayed"
@@ -45,6 +46,7 @@ description: Browse and inspect stored memories via client.memories.
   <Tab title="Node">
     ```ts
     const result = await client.memories.list({
+      actorId: 'user_42',         // optional: filter to a single actor's memories
       kind: 'semantic',
       type: 'preference',
       status: 'active',
@@ -63,6 +65,8 @@ description: Browse and inspect stored memories via client.memories.
 </Tabs>
 
 ### Pagination
+
+Pagination is stable across pages — the server always sorts by your chosen sort key with `memory_id` as a secondary tiebreaker, so iterating `offset` won't return duplicates or skip records even when many memories share the primary sort value (e.g. identical `observed_at`).
 
 <Tabs>
   <Tab title="Python">
@@ -155,7 +159,7 @@ Aggregate statistics for all memories in the org:
 | `status` | `str` | `"active"`, `"archived"`, or `"decayed"`. |
 | `text` | `str` | The extracted memory text. |
 | `confidence` | `float` | Extraction confidence (0–1). |
-| `strength` | `float` | Reinforcement strength (0–1). |
+| `strength` | `float` | Reinforcement strength (0–5.0, default 1.0). Not a probability. |
 | `recall_count` | `int` | Number of times this memory was recalled in search. |
 | `decay_half_life_days` | `float` | Days until strength halves. |
 | `pinned` | `bool` | Pinned memories never decay. |

--- a/docs/content/docs/faq.mdx
+++ b/docs/content/docs/faq.mdx
@@ -21,12 +21,9 @@ description: Answers to questions we hear most often.
   </Accordion>
 
   <Accordion title="How do I delete data?">
-    Two mechanisms:
+    Use **Dashboard → Data** for actor-level deletion and export. It gives you a confirmation receipt and logs the deletion, which is what you want for GDPR / DSAR requests.
 
-    - `client.clear(container_tag)` (Python) / `client.clear(containerTag)` (Node) — clears tracking state for a container/conversation tag.
-    - **Dashboard → Data** supports broader actor-level deletion and export.
-
-    For GDPR / DSAR requests, use the dashboard — it gives you a confirmation receipt and logs the deletion.
+    `client.clear(container_tag)` (Python) and `client.clear(containerTag)` (Node) are currently stubs — the server returns `501 Not Implemented`, calling either raises `MemsyAPIError`, and nothing is deleted server-side. A real actor-scoped delete is being designed; until then, use the dashboard for any deletion need.
   </Accordion>
 
   <Accordion title="Are the SDKs thread/concurrency safe?">

--- a/docs/content/docs/ingesting-events.mdx
+++ b/docs/content/docs/ingesting-events.mdx
@@ -275,7 +275,7 @@ Recommended batch size: tens to low hundreds. Very large batches (thousands) inc
 ## Idempotency
 
 - Memsy de-duplicates within a rolling **60-second window** by `(actor_id, session_id, kind, content)` hash. Identical re-posts within the window are collapsed and the response returns the **original** `event_id` for each duplicate, so SDK retries and `status()` lookups continue to work.
-- The window length is configurable on the platform via `MEMSY_DEDUPE_WINDOW_SEC` (default `60`); dedup is best-effort and degrades to no-dedup if the platform's Redis is unavailable.
+- Dedup is best-effort — under platform degradation you may still see fresh `event_id`s for duplicate submissions. Treat the window as a safety net for transient retries, not a guarantee.
 - If you genuinely need to re-ingest after the window, change any of the four fields — typically by appending `ts` to the content or sending a fresh `session_id`.
 
 ## Validation rules
@@ -286,9 +286,9 @@ Recommended batch size: tens to low hundreds. Very large batches (thousands) inc
 - `actor_id` and `session_id` must be non-empty after trimming whitespace; both are capped at **256 characters**.
 - `role_id` and `team_id` are also capped at **256 characters** and collapse to `null` when only whitespace.
 - `metadata` is capped at **4096 characters**.
-- All string fields silently drop NUL bytes — they would otherwise be rejected by the storage layer.
+- NUL bytes are silently stripped from all string fields before persistence.
 
-Invalid JSON in `metadata` is **not** a validation error: the server stores it under `{"raw": <original_str>}` on the event and exposes it back under `source_metadata` on derived memories.
+Invalid JSON in `metadata` is **not** a validation error: the original string is preserved as `{"raw": <original_str>}` on the event and surfaces back under `source_metadata` on derived memories.
 
 ## Failure modes
 

--- a/docs/content/docs/ingesting-events.mdx
+++ b/docs/content/docs/ingesting-events.mdx
@@ -196,6 +196,8 @@ Backfilled events with explicit timestamps get the same treatment as live events
 
 Memsy echoes the raw metadata string back in each `SearchResult` so you can deserialize it client-side.
 
+Extracted memories carry the metadata of the source event(s) they were derived from under `metadata.source_metadata` on each search result — up to 5 entries per memory. Each entry is `{event_id, metadata: <parsed dict>}` when the original string parsed as a JSON object, or `{event_id, raw: <original string>}` otherwise. **You will not lose the metadata you sent**, even if it wasn't valid JSON: the server preserves the original under `raw` instead of rejecting the ingest.
+
 ## Batching
 
 `ingest()` is designed for batches. Send many events in one call whenever you can:
@@ -272,8 +274,21 @@ Recommended batch size: tens to low hundreds. Very large batches (thousands) inc
 
 ## Idempotency
 
-- Memsy de-duplicates within a short rolling window by `(actor_id, session_id, kind, content)` hash. Re-sending the same event back-to-back won't double-count.
-- If you genuinely need to re-ingest, change any of the four fields — typically by appending `ts` to the content or sending a fresh `session_id`.
+- Memsy de-duplicates within a rolling **60-second window** by `(actor_id, session_id, kind, content)` hash. Identical re-posts within the window are collapsed and the response returns the **original** `event_id` for each duplicate, so SDK retries and `status()` lookups continue to work.
+- The window length is configurable on the platform via `MEMSY_DEDUPE_WINDOW_SEC` (default `60`); dedup is best-effort and degrades to no-dedup if the platform's Redis is unavailable.
+- If you genuinely need to re-ingest after the window, change any of the four fields — typically by appending `ts` to the content or sending a fresh `session_id`.
+
+## Validation rules
+
+`POST /v1/ingest` returns `422` if any event fails validation:
+
+- `content` must contain at least one non-whitespace character and stay under **8000 characters**.
+- `actor_id` and `session_id` must be non-empty after trimming whitespace; both are capped at **256 characters**.
+- `role_id` and `team_id` are also capped at **256 characters** and collapse to `null` when only whitespace.
+- `metadata` is capped at **4096 characters**.
+- All string fields silently drop NUL bytes — they would otherwise be rejected by the storage layer.
+
+Invalid JSON in `metadata` is **not** a validation error: the server stores it under `{"raw": <original_str>}` on the event and exposes it back under `source_metadata` on derived memories.
 
 ## Failure modes
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -198,7 +198,7 @@ In three calls you:
 
 And as a bonus:
 
-- Every response has `usage` populated from `X-Usage-*` response headers — you already know how much of your plan you've used. `rateLimit` / `rate_limit` is populated from `X-RateLimit-*` headers when the server returns them.
+- Every authenticated response has `usage` (`X-Usage-*`) and `rateLimit` / `rate_limit` (`X-RateLimit-Limit`/`-Remaining`/`-Reset`) populated — you already know how much of your plan you've used and how many calls remain.
 - Rate-limited calls (HTTP 429) are retried automatically with exponential backoff. No code to write.
 - HTTP errors come back as typed exceptions in both SDKs (`AuthenticationError`/`MemsyAuthError`, `UsageLimitExceeded`, `MemsyRateLimitError`, …).
 

--- a/docs/content/docs/reference/node/memsy-client.mdx
+++ b/docs/content/docs/reference/node/memsy-client.mdx
@@ -123,7 +123,7 @@ console.log(h.billingEnabled);  // true | false | null
 
 ### `clear(containerTag)`
 
-Reset state for a container tag. Returns the number of records deleted.
+Reset state for a container tag. Returns the number of records deleted (when implemented).
 
 ```ts
 clear(containerTag: string): Promise<ClearResponse>
@@ -135,7 +135,10 @@ console.log(`Deleted ${result.deleted} records`);
 ```
 
 <Warning>
-`clear` is destructive — it removes memories permanently. Most apps will never call this; it's primarily useful in tests and dev environments.
+**Currently a stub.** The server returns `501 Not Implemented` until a real
+actor-scoped delete is wired up; calling `clear()` will throw `MemsyAPIError`.
+Avoid calling it in production paths. Track the SDK CHANGELOG for the
+implementation announcement.
 </Warning>
 
 ## Common patterns

--- a/docs/content/docs/reference/node/models.mdx
+++ b/docs/content/docs/reference/node/models.mdx
@@ -79,8 +79,19 @@ Every successful response carries `usage` and `rateLimit` parsed from response h
 | `id`            | `string`                              | Memory ID.                                                            |
 | `content`       | `string`                              | Extracted memory text.                                                |
 | `score`         | `number`                              | Similarity score `0.0` (none) – `1.0` (exact).                        |
-| `metadata`      | `Record<string, unknown> \| null`     | Any metadata captured during extraction.                              |
+| `metadata`      | `Record<string, unknown> \| null`     | Server-attached fields: `type`, `kind`, `strength`, `confidence`, `entities`, `source_metadata`, … |
 | `sourceEvents`  | `SourceEvent[] \| null`               | Originating events — populated when `includeSourceEvents: true`.      |
+| `sourceMetadata`| `SourceMetadata[] \| null`            | User-supplied metadata from source event(s); capped at 5 entries.     |
+
+### `SourceMetadata`
+
+User-supplied event metadata propagated to memories derived from those events. Surfaced on `SearchResult.sourceMetadata`.
+
+| Field      | Type                              | Description                                                                 |
+|------------|-----------------------------------|-----------------------------------------------------------------------------|
+| `eventId`  | `string`                          | The originating event's ID.                                                 |
+| `metadata` | `Record<string, unknown>` (opt.)  | Parsed object when the event's `metadata` string was valid JSON object.     |
+| `raw`      | `string` (opt.)                   | Original string when the event's `metadata` was not a JSON object.          |
 
 ### `SourceEvent`
 
@@ -167,8 +178,10 @@ Parsed from `X-RateLimit-*` headers.
 | Field        | Type             | Description                                                     |
 |--------------|------------------|-----------------------------------------------------------------|
 | `limit`      | `number \| null` | Max requests allowed in the current window.                     |
-| `remaining`  | `number \| null` | Requests remaining.                                             |
-| `reset`      | `number \| null` | Unix timestamp (seconds) when the window resets.                |
+| `remaining`  | `number \| null` | Calls remaining in the current period (clamped at 0).           |
+| `reset`      | `number \| null` | Unix timestamp (seconds) of the next billing-period boundary.   |
+
+Populated on every authenticated response — the rate-limit dimension is `api_calls`.
 
 ```ts
 const { rateLimit } = await client.search('preferences');
@@ -211,7 +224,7 @@ All three share a common shape and differ only in the ID fields.
 | `status`             | `string`                          | `"active"` / `"archived"` / `"decayed"`.     |
 | `text`               | `string`                          | The extracted memory text.                   |
 | `confidence`         | `number`                          | Extraction confidence (0–1).                 |
-| `strength`           | `number`                          | Reinforcement strength (0–1).                |
+| `strength`           | `number`                          | Reinforcement strength (0–5.0, default 1.0). Not a probability. |
 | `recallCount`        | `number`                          | Times recalled in search.                    |
 | `decayHalfLifeDays`  | `number`                          | Days until strength halves.                  |
 | `pinned`             | `boolean`                         | Pinned memories never decay.                 |

--- a/docs/content/docs/reference/node/resources.mdx
+++ b/docs/content/docs/reference/node/resources.mdx
@@ -75,6 +75,7 @@ Read-only console memory browsing.
 
 ```ts
 await client.memories.list({                                  // MemoryListResponse
+  actorId: 'user_42',                                         // filter to a single actor
   kind: 'semantic',
   type: 'preference',
   status: 'active',
@@ -86,6 +87,8 @@ await client.memories.list({                                  // MemoryListRespo
 await client.memories.stats();                                // MemoryStatsResponse
 await client.memories.get(memoryId);                          // MemoryItem
 ```
+
+Pagination is stable across pages: the server always sorts with `memory_id` as a secondary tiebreaker, so walking `offset` won't return duplicates or skip records.
 
 | Method | Signature |
 |---|---|

--- a/docs/content/docs/reference/python/async-memsy-client.mdx
+++ b/docs/content/docs/reference/python/async-memsy-client.mdx
@@ -42,7 +42,7 @@ Each method has the same signature as the sync client but returns a coroutine.
 | `await search(query, *, actor_id, limit, threshold, include_source_events)` | `SearchResponse` |
 | `await status(event_ids)` | `StatusResponse` |
 | `await health()` | `HealthResponse` |
-| `await clear(container_tag)` | `ClearResponse` |
+| `await clear(container_tag)` | `ClearResponse` (currently a `501 Not Implemented` stub — see [retries notes](/docs/retries#idempotency-considerations)) |
 | `await close()` | `None` |
 
 All raise the same exceptions as the sync client.

--- a/docs/content/docs/reference/python/async-memsy-client.mdx
+++ b/docs/content/docs/reference/python/async-memsy-client.mdx
@@ -3,7 +3,7 @@ title: AsyncMemsyClient
 description: Async HTTP client — mirrors MemsyClient method-for-method.
 ---
 
-Asynchronous HTTP client for the Memsy hot-path API. Mirrors **[`MemsyClient`](/docs/reference/python/memsy-client)** method-for-method.
+Asynchronous HTTP client for the Memsy API. Mirrors **[`MemsyClient`](/docs/reference/python/memsy-client)** method-for-method.
 
 ```python
 from memsy import AsyncMemsyClient

--- a/docs/content/docs/reference/python/memsy-client.mdx
+++ b/docs/content/docs/reference/python/memsy-client.mdx
@@ -117,12 +117,12 @@ clear(container_tag: str) -> ClearResponse
 |---|---|---|
 | `container_tag` | `str` | Container/conversation tag to clear. |
 
-<Callout type="warn">
+<Warning>
   **Currently a stub.** The server returns `501 Not Implemented` until a real
   actor-scoped delete is wired up; calling `clear()` will raise
   `MemsyAPIError`. Avoid calling it in production paths. Track the SDK
   CHANGELOG for the implementation announcement.
-</Callout>
+</Warning>
 
 **Returns** (when implemented): `ClearResponse` with `deleted` (count of cleared items).
 

--- a/docs/content/docs/reference/python/memsy-client.mdx
+++ b/docs/content/docs/reference/python/memsy-client.mdx
@@ -188,6 +188,7 @@ Browse and inspect stored memories. See **[Console Memories](/docs/console-memor
 ```python
 client.memories.list(
     *,
+    actor_id: str | None = None,  # filter to a single actor's memories
     kind: str | None = None,
     type: str | None = None,
     status: str | None = None,
@@ -200,6 +201,8 @@ client.memories.list(
 client.memories.get(memory_id: str) -> MemoryItemResource
 client.memories.stats() -> MemoryStatsResponse
 ```
+
+Pagination is stable across pages: every sort includes `memory_id` as a secondary tiebreaker, so walking `offset` won't return duplicates or skip records.
 
 ---
 

--- a/docs/content/docs/reference/python/memsy-client.mdx
+++ b/docs/content/docs/reference/python/memsy-client.mdx
@@ -3,7 +3,7 @@ title: MemsyClient
 description: Synchronous HTTP client — constructor, methods, parameters, exceptions.
 ---
 
-Synchronous HTTP client for the Memsy hot-path API (memsy-core).
+Synchronous HTTP client for the Memsy API.
 
 ```python
 from memsy import MemsyClient

--- a/docs/content/docs/reference/python/memsy-client.mdx
+++ b/docs/content/docs/reference/python/memsy-client.mdx
@@ -117,7 +117,14 @@ clear(container_tag: str) -> ClearResponse
 |---|---|---|
 | `container_tag` | `str` | Container/conversation tag to clear. |
 
-**Returns**: `ClearResponse` with `deleted` (count of cleared items).
+<Callout type="warn">
+  **Currently a stub.** The server returns `501 Not Implemented` until a real
+  actor-scoped delete is wired up; calling `clear()` will raise
+  `MemsyAPIError`. Avoid calling it in production paths. Track the SDK
+  CHANGELOG for the implementation announcement.
+</Callout>
+
+**Returns** (when implemented): `ClearResponse` with `deleted` (count of cleared items).
 
 ---
 

--- a/docs/content/docs/reference/python/models.mdx
+++ b/docs/content/docs/reference/python/models.mdx
@@ -19,11 +19,11 @@ from memsy import (
     StatusResponse,
     HealthResponse,
     ClearResponse,
-    # Onboarding (memsy-core)
+    # Onboarding
     OrgResource,
     RoleResource,
     TeamResource,
-    # Console memories (memsy-core)
+    # Console memories
     MemoryScopeInfo,
     MemoryItemResource,
     MemoryListResponse,
@@ -181,7 +181,7 @@ class ClearResponse:
 
 ---
 
-## Onboarding models (memsy-core)
+## Onboarding models
 
 Returned by `client.orgs.*`, `client.roles.*`, and `client.teams.*`.
 
@@ -231,7 +231,7 @@ class TeamResource:
 
 ---
 
-## Console memory models (memsy-core)
+## Console memory models
 
 Returned by `client.memories.*`.
 
@@ -262,7 +262,7 @@ class MemoryItemResource:
     status: str
     text: str
     confidence: float
-    strength: float  # bounded 0.0–5.0 by PolicyConfig.max_strength
+    strength: float  # bounded 0.0–5.0 by platform policy
     recall_count: int
     decay_half_life_days: float
     pinned: bool

--- a/docs/content/docs/reference/python/models.mdx
+++ b/docs/content/docs/reference/python/models.mdx
@@ -120,11 +120,12 @@ class SearchResult:
 | `.entities` | `list[dict]` | Named entities extracted during processing. |
 | `.kind` | `str \| None` | Memory kind (e.g. `"semantic"`, `"episodic"`). |
 | `.type` | `str \| None` | Memory type (e.g. `"preference"`, `"fact"`). |
-| `.strength` | `float \| None` | Reinforcement strength (0–1). |
+| `.strength` | `float \| None` | Reinforcement strength (0–5.0). Not a probability. |
 | `.confidence` | `float \| None` | Extraction confidence (0–1). |
 | `.observed_at` | `str \| None` | ISO-8601 timestamp when memory was observed. |
 | `.source_event_ids` | `list[str]` | IDs of the source events. |
 | `.source_events` | `list[SourceEvent]` | Hydrated source events (requires `include_source_events=True`). |
+| `.source_metadata` | `list[dict]` | User-supplied metadata from source event(s). Each entry is `{event_id, metadata: dict}` for JSON-object payloads or `{event_id, raw: str}` for non-JSON. Capped at 5. |
 
 ### `SourceEvent`
 
@@ -261,7 +262,7 @@ class MemoryItemResource:
     status: str
     text: str
     confidence: float
-    strength: float
+    strength: float  # bounded 0.0–5.0 by PolicyConfig.max_strength
     recall_count: int
     decay_half_life_days: float
     pinned: bool

--- a/docs/content/docs/retries.mdx
+++ b/docs/content/docs/retries.mdx
@@ -119,7 +119,7 @@ The SDK raises a rate-limit exception with the `Retry-After` value populated if 
 ## Idempotency considerations
 
 - `search()` and `status()` are read-only and always safe to retry.
-- `ingest()` is **safe to retry within a rolling 60-second window**. The server hashes `(actor_id, session_id, kind, content)` and collapses identical tuples to a single stored event, returning the **original** `event_id` for duplicates so subsequent `status()` calls still work. The window length is configurable on the platform via `MEMSY_DEDUPE_WINDOW_SEC` (default 60s). Dedup is best-effort — if the platform's Redis is unavailable the path degrades to no-dedup and you'll see fresh event IDs. For retries outside the window or cross-process exactly-once needs, keep a client-side log of submitted hashes.
+- `ingest()` is **safe to retry within a rolling 60-second window**. The platform hashes `(actor_id, session_id, kind, content)` and collapses identical tuples to a single stored event, returning the **original** `event_id` for duplicates so subsequent `status()` calls still work. Dedup is best-effort — under platform degradation you may still see fresh `event_id`s for duplicate submissions, so for retries outside the window or cross-process exactly-once needs, keep a client-side log of submitted hashes.
 - `clear()` is currently a stub that returns **501 Not Implemented** — it does not delete anything. A real actor-scoped delete is being designed; until then, calling `clear()` will raise `MemsyAPIError` (Python) / `MemsyAPIError` (Node). Avoid calling it in production paths.
 
 ## Timeouts

--- a/docs/content/docs/retries.mdx
+++ b/docs/content/docs/retries.mdx
@@ -119,7 +119,7 @@ The SDK raises a rate-limit exception with the `Retry-After` value populated if 
 ## Idempotency considerations
 
 - `search()` and `status()` are read-only and always safe to retry.
-- `ingest()` is **not** currently idempotent on the server side. Retrying a batch after a 429 will create duplicate events. If you need exactly-once delivery, dedupe on the client before sending — for example, keep a local log of `(actor_id, session_id, kind, content_hash, ts)` tuples and skip rows that have already succeeded. Server-side dedupe may land in a future release; watch the SDK CHANGELOG for the announcement.
+- `ingest()` is **safe to retry within a rolling 60-second window**. The server hashes `(actor_id, session_id, kind, content)` and collapses identical tuples to a single stored event, returning the **original** `event_id` for duplicates so subsequent `status()` calls still work. The window length is configurable on the platform via `MEMSY_DEDUPE_WINDOW_SEC` (default 60s). Dedup is best-effort — if the platform's Redis is unavailable the path degrades to no-dedup and you'll see fresh event IDs. For retries outside the window or cross-process exactly-once needs, keep a client-side log of submitted hashes.
 - `clear()` is currently a stub that returns **501 Not Implemented** — it does not delete anything. A real actor-scoped delete is being designed; until then, calling `clear()` will raise `MemsyAPIError` (Python) / `MemsyAPIError` (Node). Avoid calling it in production paths.
 
 ## Timeouts

--- a/docs/content/docs/retries.mdx
+++ b/docs/content/docs/retries.mdx
@@ -118,10 +118,9 @@ The SDK raises a rate-limit exception with the `Retry-After` value populated if 
 
 ## Idempotency considerations
 
-- `search()` is read-only and always safe to retry.
-- `ingest()` is idempotent within a short rolling window — the server de-duplicates by content hash. Retrying a batch after a 429 is safe.
-- `status()` is read-only.
-- `clear()` is idempotent by definition.
+- `search()` and `status()` are read-only and always safe to retry.
+- `ingest()` is **not** currently idempotent on the server side. Retrying a batch after a 429 will create duplicate events. If you need exactly-once delivery, dedupe on the client before sending — for example, keep a local log of `(actor_id, session_id, kind, content_hash, ts)` tuples and skip rows that have already succeeded. Server-side dedupe may land in a future release; watch the SDK CHANGELOG for the announcement.
+- `clear()` is currently a stub that returns **501 Not Implemented** — it does not delete anything. A real actor-scoped delete is being designed; until then, calling `clear()` will raise `MemsyAPIError` (Python) / `MemsyAPIError` (Node). Avoid calling it in production paths.
 
 ## Timeouts
 

--- a/docs/content/docs/searching-memory.mdx
+++ b/docs/content/docs/searching-memory.mdx
@@ -100,20 +100,23 @@ When `true`, each result additionally includes the source events the memory was 
     ```python
     results.results  # list[SearchResult]
 
-    r.id        # stable memory ID
-    r.content   # natural-language memory, e.g. "User prefers dark mode"
-    r.score     # float; higher = closer match
-    r.metadata  # dict | None — whatever app-level data was attached
+    r.id                # stable memory ID
+    r.content           # natural-language memory, e.g. "User prefers dark mode"
+    r.score             # float; higher = closer match
+    r.metadata          # dict | None — server-attached fields (type, kind, …)
+    r.strength          # float — reinforcement strength, bounded 0.0–5.0
+    r.source_metadata   # list[dict] — user metadata from the originating event(s)
     ```
   </Tab>
   <Tab title="Node">
     ```ts
     results.results;  // SearchResult[]
 
-    r.id;        // stable memory ID
-    r.content;   // natural-language memory, e.g. "User prefers dark mode"
-    r.score;     // number; higher = closer match
-    r.metadata;  // Record<string, unknown> | null
+    r.id;              // stable memory ID
+    r.content;         // natural-language memory
+    r.score;           // number; higher = closer match
+    r.metadata;        // Record<string, unknown> | null
+    r.sourceMetadata;  // SourceMetadata[] | null — user metadata from source events
     ```
   </Tab>
   <Tab title="cURL">
@@ -124,13 +127,23 @@ When `true`, each result additionally includes the source events the memory was 
           "id": "01JK...",
           "content": "User prefers dark mode across apps.",
           "score": 0.84,
-          "metadata": null
+          "metadata": {
+            "type": "preference",
+            "strength": 1.5,
+            "source_metadata": [
+              { "event_id": "01JK...", "metadata": { "plan": "pro" } }
+            ]
+          }
         }
       ]
     }
     ```
   </Tab>
 </Tabs>
+
+`strength` is a reinforcement signal bounded `0.0`–`5.0` by the platform's policy ceiling; it rises by a small amount each time a memory is returned by `search()` and decays slowly when unused. **Not** a probability — don't normalise it into the `[0, 1]` range.
+
+`source_metadata` carries the JSON metadata you passed at ingest, attached to the originating event(s) the memory was derived from. Up to 5 entries; each entry is `{event_id, metadata: {...}}` for valid JSON-object payloads or `{event_id, raw: "..."}` otherwise. Use it for tagging, filtering, or correlating back to your application's own records.
 
 ## Reading usage and rate-limit info
 

--- a/docs/content/docs/usage-and-rate-limits.mdx
+++ b/docs/content/docs/usage-and-rate-limits.mdx
@@ -8,7 +8,7 @@ Every successful response from the Memsy API carries HTTP headers describing you
 - `usage` — a `UsageInfo`, from `X-Usage-*` and `X-Plan` headers.
 - `rate_limit` (Python) / `rateLimit` (Node) — a `RateLimitInfo`, from `X-RateLimit-*` headers.
 
-Both may be `None` / `null` if the server didn't return the corresponding headers.
+The rate-limit triple is **populated on every authenticated response** (its dimension is `api_calls`); `usage` may still be `None` / `null` on routes that don't carry usage headers (e.g. `/health`).
 
 ## Accessing usage
 
@@ -99,9 +99,9 @@ Fields on `RateLimitInfo`:
 
 | Field | Description |
 |---|---|
-| `limit` | Max requests per window. |
-| `remaining` | Requests remaining in the current window. |
-| `reset` | Unix timestamp when the window resets. |
+| `limit` | Plan limit for the `api_calls` dimension this billing period. |
+| `remaining` | Calls remaining in the current period (clamped at `0`). |
+| `reset` | Unix timestamp (UTC) of the next billing-period boundary — the start of the next month. |
 
 ## Underlying headers
 
@@ -190,7 +190,7 @@ Fields on `RateLimitInfo`:
 ## When usage is missing
 
 <Note>
-If `response.usage` is `None`, the server didn't emit usage headers for that response (e.g. `/health` may omit them). That is not an error.
+`response.usage` may be `None` on routes that don't carry usage headers (e.g. `/health`). That is not an error. `rate_limit` / `rateLimit` is populated on every authenticated response.
 </Note>
 
 ## Next

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -25,7 +25,7 @@ export interface SearchOptions {
 }
 
 /**
- * Memsy hot-path client (memsy-core).
+ * Memsy client — ingest, search, and read back memories.
  *
  * Sub-resources mirror the Python SDK's MemsyClient:
  *   client.orgs       — onboarding org CRUD

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -7,6 +7,7 @@ import {
   type SearchResponse,
   type StatusResponse,
   parseSourceEvents,
+  parseSourceMetadata,
   serializeEvent,
 } from "./models.js";
 import { OrgsResource } from "./resources/orgs.js";
@@ -80,6 +81,7 @@ export class MemsyClient extends BaseHttpClient {
         score: r.score,
         metadata: r.metadata ?? null,
         sourceEvents: parseSourceEvents(r.metadata),
+        sourceMetadata: parseSourceMetadata(r.metadata),
       })),
       usage,
       rateLimit,

--- a/sdks/node/src/models.ts
+++ b/sdks/node/src/models.ts
@@ -114,8 +114,8 @@ export interface SearchResult {
   metadata: Record<string, unknown> | null;
   sourceEvents: SourceEvent[] | null;
   /**
-   * User-supplied metadata propagated from the source event(s) this memory was
-   * extracted from. Capped at 5 entries by the server.
+   * User-supplied metadata propagated from the source event(s) this memory
+   * was extracted from. Capped at 5 entries.
    */
   sourceMetadata: SourceMetadata[] | null;
 }
@@ -288,8 +288,9 @@ export interface MemoryItem {
   text: string;
   confidence: number;
   /**
-   * Reinforcement strength. Bounded 0.0–5.0 by the memsy-core policy ceiling
-   * (PolicyConfig.max_strength). Not a probability.
+   * Reinforcement strength, bounded 0.0–5.0 by platform policy. Starts at
+   * 1.0 and grows with search hits; not a probability — don't normalise
+   * to [0, 1].
    */
   strength: number;
   recallCount: number;

--- a/sdks/node/src/models.ts
+++ b/sdks/node/src/models.ts
@@ -142,7 +142,11 @@ export function parseSourceMetadata(
   if (!Array.isArray(raw)) return null;
   return raw.map((entry: Record<string, unknown>) => {
     const out: SourceMetadata = { eventId: String(entry.event_id ?? "") };
-    if (entry.metadata && typeof entry.metadata === "object") {
+    if (
+      entry.metadata &&
+      typeof entry.metadata === "object" &&
+      !Array.isArray(entry.metadata)
+    ) {
       out.metadata = entry.metadata as Record<string, unknown>;
     }
     if (typeof entry.raw === "string") {

--- a/sdks/node/src/models.ts
+++ b/sdks/node/src/models.ts
@@ -99,12 +99,25 @@ export interface SourceEvent {
   ts: string | null;
 }
 
+export interface SourceMetadata {
+  eventId: string;
+  /** Parsed metadata when the originating event's `metadata` was a JSON object. */
+  metadata?: Record<string, unknown>;
+  /** Raw string when the originating event's `metadata` was not a JSON object. */
+  raw?: string;
+}
+
 export interface SearchResult {
   id: string;
   content: string;
   score: number;
   metadata: Record<string, unknown> | null;
   sourceEvents: SourceEvent[] | null;
+  /**
+   * User-supplied metadata propagated from the source event(s) this memory was
+   * extracted from. Capped at 5 entries by the server.
+   */
+  sourceMetadata: SourceMetadata[] | null;
 }
 
 export function parseSourceEvents(
@@ -119,6 +132,24 @@ export function parseSourceEvents(
     content: String(e.content ?? ""),
     ts: typeof e.ts === "string" ? e.ts : null,
   }));
+}
+
+export function parseSourceMetadata(
+  metadata: Record<string, unknown> | null | undefined
+): SourceMetadata[] | null {
+  if (!metadata) return null;
+  const raw = metadata.source_metadata;
+  if (!Array.isArray(raw)) return null;
+  return raw.map((entry: Record<string, unknown>) => {
+    const out: SourceMetadata = { eventId: String(entry.event_id ?? "") };
+    if (entry.metadata && typeof entry.metadata === "object") {
+      out.metadata = entry.metadata as Record<string, unknown>;
+    }
+    if (typeof entry.raw === "string") {
+      out.raw = entry.raw;
+    }
+    return out;
+  });
 }
 
 export interface SearchResponse {
@@ -252,6 +283,10 @@ export interface MemoryItem {
   status: string;
   text: string;
   confidence: number;
+  /**
+   * Reinforcement strength. Bounded 0.0–5.0 by the memsy-core policy ceiling
+   * (PolicyConfig.max_strength). Not a probability.
+   */
   strength: number;
   recallCount: number;
   decayHalfLifeDays: number;

--- a/sdks/node/src/resources/memories.ts
+++ b/sdks/node/src/resources/memories.ts
@@ -9,6 +9,7 @@ import {
 } from "../models.js";
 
 export interface MemoryListOptions {
+  actorId?: string;
   kind?: string;
   type?: string;
   status?: string;
@@ -30,6 +31,7 @@ export class MemoriesResource {
           sort: options.sort ?? "observed_at_desc",
           limit: options.limit ?? 50,
           offset: options.offset ?? 0,
+          actor_id: options.actorId,
           kind: options.kind,
           type: options.type,
           status: options.status,

--- a/sdks/python/memsy/__init__.py
+++ b/sdks/python/memsy/__init__.py
@@ -1,11 +1,11 @@
 """
 Memsy Python SDK — official client for the Memsy memory service.
 
-Quick start (hot-path memory)::
+Quick start::
 
     from memsy import MemsyClient, EventPayload
 
-    client = MemsyClient(base_url="https://your-memsy-core-url", api_key="msy_...")
+    client = MemsyClient(base_url="https://api.memsy.io/v1", api_key="msy_...")
     health = client.health()
 
     # Ingest events

--- a/sdks/python/memsy/async_client.py
+++ b/sdks/python/memsy/async_client.py
@@ -25,7 +25,7 @@ from memsy.resources.teams import AsyncTeamsResource
 
 class AsyncMemsyClient(HttpCoreMixin):
     """
-    Asynchronous Memsy SDK client for the hot-path memory engine (memsy-core).
+    Asynchronous Memsy SDK client.
 
     Usage::
 

--- a/sdks/python/memsy/client.py
+++ b/sdks/python/memsy/client.py
@@ -25,7 +25,7 @@ from memsy.resources.teams import TeamsResource
 
 class MemsyClient(HttpCoreMixin):
     """
-    Synchronous Memsy SDK client for the hot-path memory engine (memsy-core).
+    Synchronous Memsy SDK client.
 
     Usage::
 

--- a/sdks/python/memsy/models.py
+++ b/sdks/python/memsy/models.py
@@ -389,8 +389,6 @@ class MemoryItemResource:
     status: str
     text: str
     confidence: float
-    # `strength` is bounded 0.0–5.0 by the memsy-core policy ceiling
-    # (PolicyConfig.max_strength). Not a probability.
     strength: float
     recall_count: int
     decay_half_life_days: float

--- a/sdks/python/memsy/models.py
+++ b/sdks/python/memsy/models.py
@@ -186,6 +186,15 @@ class SearchResult:
         return [SourceEvent.from_dict(e) for e in raw]
 
     @property
+    def source_metadata(self) -> list[dict[str, Any]]:
+        """User-supplied metadata from the source event(s) this memory was
+        extracted from. Each entry is `{"event_id": str, "metadata": dict}` for
+        JSON-object payloads, or `{"event_id": str, "raw": str}` for non-JSON
+        strings the caller passed. Capped at 5 entries.
+        """
+        return self._meta("source_metadata") or []
+
+    @property
     def kind(self) -> str | None:
         return self._meta("kind")
 
@@ -195,6 +204,8 @@ class SearchResult:
 
     @property
     def strength(self) -> float | None:
+        """Reinforcement strength. Bounded ``0.0`` to ``5.0`` (policy ceiling
+        on memsy-core); not a probability."""
         return self._meta("strength")
 
     @property
@@ -378,6 +389,8 @@ class MemoryItemResource:
     status: str
     text: str
     confidence: float
+    # `strength` is bounded 0.0–5.0 by the memsy-core policy ceiling
+    # (PolicyConfig.max_strength). Not a probability.
     strength: float
     recall_count: int
     decay_half_life_days: float

--- a/sdks/python/memsy/models.py
+++ b/sdks/python/memsy/models.py
@@ -204,8 +204,9 @@ class SearchResult:
 
     @property
     def strength(self) -> float | None:
-        """Reinforcement strength. Bounded ``0.0`` to ``5.0`` (policy ceiling
-        on memsy-core); not a probability."""
+        """Reinforcement strength, bounded ``0.0``–``5.0`` by platform policy.
+        Starts at 1.0 and grows with search hits; not a probability —
+        don't normalise to [0, 1]."""
         return self._meta("strength")
 
     @property
@@ -287,7 +288,7 @@ class ClearResponse:
         return cls(deleted=data.get("deleted", 0))
 
 
-# ============== Onboarding Models (memsy-core) ==============
+# ============== Onboarding Models ==============
 
 
 def _onboarding_base(data: dict[str, Any]) -> dict[str, Any]:
@@ -303,7 +304,7 @@ def _onboarding_base(data: dict[str, Any]) -> dict[str, Any]:
 
 @dataclass
 class OrgResource:
-    """An org customization record from the memsy-core onboarding API."""
+    """An org customization record from the onboarding API."""
 
     org_id: str
     name: str
@@ -320,7 +321,7 @@ class OrgResource:
 
 @dataclass
 class RoleResource:
-    """A role customization record from the memsy-core onboarding API."""
+    """A role customization record from the onboarding API."""
 
     role_id: str
     org_id: str
@@ -338,7 +339,7 @@ class RoleResource:
 
 @dataclass
 class TeamResource:
-    """A team customization record from the memsy-core onboarding API."""
+    """A team customization record from the onboarding API."""
 
     team_id: str
     org_id: str
@@ -354,7 +355,7 @@ class TeamResource:
         return cls(team_id=data["team_id"], org_id=data["org_id"], **_onboarding_base(data))
 
 
-# ============== Console Memory Models (memsy-core) ==============
+# ============== Console Memory Models ==============
 
 
 @dataclass

--- a/sdks/python/memsy/resources/memories.py
+++ b/sdks/python/memsy/resources/memories.py
@@ -18,6 +18,7 @@ class MemoriesResource:
     def list(
         self,
         *,
+        actor_id: str | None = None,
         kind: str | None = None,
         type: str | None = None,
         status: str | None = None,
@@ -29,6 +30,7 @@ class MemoriesResource:
         """
         Browse memories for the authenticated org.
 
+        :param actor_id: Filter to memories scoped to a single actor.
         :param kind: Filter by memory_kind (e.g. ``"semantic"``, ``"episodic"``, ``"procedural"``).
         :param type: Filter by type (e.g. ``"fact"``, ``"preference"``, ``"norm"``).
         :param status: Filter by status. Defaults to ``"active"`` on the server.
@@ -36,9 +38,12 @@ class MemoriesResource:
                      ``"strength_desc"``, ``"confidence_desc"``, ``"created_at_desc"``.
         :param search: Substring text filter applied server-side.
         :param limit: Page size (1–200, default 50).
-        :param offset: Pagination offset.
+        :param offset: Pagination offset. Results are stable across pages — the
+                       sort always includes ``memory_id`` as a tiebreaker.
         """
         params: dict[str, object] = {"sort": sort, "limit": limit, "offset": offset}
+        if actor_id is not None:
+            params["actor_id"] = actor_id
         if kind is not None:
             params["kind"] = kind
         if type is not None:
@@ -70,6 +75,7 @@ class AsyncMemoriesResource:
     async def list(
         self,
         *,
+        actor_id: str | None = None,
         kind: str | None = None,
         type: str | None = None,
         status: str | None = None,
@@ -81,6 +87,7 @@ class AsyncMemoriesResource:
         """
         Browse memories for the authenticated org.
 
+        :param actor_id: Filter to memories scoped to a single actor.
         :param kind: Filter by memory_kind (e.g. ``"semantic"``, ``"episodic"``, ``"procedural"``).
         :param type: Filter by type (e.g. ``"fact"``, ``"preference"``, ``"norm"``).
         :param status: Filter by status. Defaults to ``"active"`` on the server.
@@ -88,9 +95,12 @@ class AsyncMemoriesResource:
                      ``"strength_desc"``, ``"confidence_desc"``, ``"created_at_desc"``.
         :param search: Substring text filter applied server-side.
         :param limit: Page size (1–200, default 50).
-        :param offset: Pagination offset.
+        :param offset: Pagination offset. Results are stable across pages — the
+                       sort always includes ``memory_id`` as a tiebreaker.
         """
         params: dict[str, object] = {"sort": sort, "limit": limit, "offset": offset}
+        if actor_id is not None:
+            params["actor_id"] = actor_id
         if kind is not None:
             params["kind"] = kind
         if type is not None:


### PR DESCRIPTION
This PR keeps the public docs and Python/Node SDKs in lockstep with the behaviour changes shipped on **[memsy-io/memsy-core#21](https://github.com/memsy-io/memsy-core/pull/21)** and **[memsy-io/api#10](https://github.com/memsy-io/api/pull/10)**. Replaces the earlier scope of this branch (BUG-15 idempotency strike); that commit is preserved in the history.

## SDK changes (callers get the new contracts automatically)

| File | Change | Why |
|---|---|---|
| `sdks/python/memsy/resources/memories.py` | `list(...)` now accepts `actor_id` | Server-side filter is wired up (was previously dropped silently). |
| `sdks/node/src/resources/memories.ts` | `MemoryListOptions.actorId` added | Same; passed through as `actor_id` query param. |
| `sdks/python/memsy/models.py` | `SearchResult.source_metadata` property; `strength` docstring notes 0.0–5.0 | New `source_metadata` field on search responses; strength ceiling is the policy cap, not a probability. |
| `sdks/node/src/models.ts` | `SourceMetadata` interface + `parseSourceMetadata`; `SearchResult.sourceMetadata`; `MemoryItem.strength` JSDoc updated | Same. |
| `sdks/node/src/client.ts` | `search()` now populates `sourceMetadata` on each result | Wires the new parser. |

## Doc changes

| File | Change | Source bug |
|---|---|---|
| `retries.mdx` | Replace the "ingest is not idempotent" warning with the real 60-second content-hash dedup contract. | BUG-10/B |
| `ingesting-events.mdx` | Document the dedup window, `source_metadata` propagation, the `{"raw": str}` fallback for non-JSON metadata, and the validation rules now enforced at the boundary. | BUG-5, BUG-6/7/8, BUG-9, BUG-10 |
| `searching-memory.mdx` | Surface `source_metadata` in the result shape; clarify `strength` is 0.0–5.0. | BUG-9, BUG-G |
| `usage-and-rate-limits.mdx` | `X-RateLimit-*` triple is now guaranteed on every authed response; scope "may be null" caveats to `UsageInfo`. | BUG-C |
| `async-processing.mdx` | Re-ingest within the window is safe and returns the original `event_id`. | BUG-10 |
| `console-memories.mdx` | Document the new `actor_id` filter, the 0–5.0 strength range, and that pagination is stable across pages. | BUG-11, BUG-A, BUG-G |
| `reference/python/memsy-client.mdx` | Add `actor_id` to `client.memories.list`; note pagination stability. | BUG-11, BUG-A |
| `reference/python/models.mdx` | `.strength` row updated to 0–5.0; new `.source_metadata` row; inline comment on the dataclass `strength` field. | BUG-G, BUG-9 |
| `reference/node/models.mdx` | New `sourceMetadata` field + `SourceMetadata` interface in `SearchResult`; `RateLimitInfo` scoped to "always populated on authed responses"; `MemoryItem.strength` documented as 0–5.0. | BUG-9, BUG-C, BUG-G |
| `reference/node/resources.mdx` | `actorId` filter shown in the `client.memories.list` example; pagination stability noted. | BUG-11, BUG-A |
| `quickstart.mdx` | Drop the "when the server returns them" hedge for `rateLimit` / `rate_limit` on authed responses. | BUG-C |

## What we deliberately did NOT change

- **`client.orgs.delete()`** in either SDK. The DELETE confirmation gate added on `api/memsy_api/http/routes/orgs.py` (PR #10) is a **control-plane** endpoint hit by the dashboard. The public SDK's `client.orgs.delete()` calls **memsy-core's** onboarding `DELETE /orgs/{id}`, which only removes the *org customisation record* — memories are unaffected — and does not require confirmation. Adding `confirm` here would have been a false breaking change.
- The pre-existing `X-Usage-ApiCall` (singular) vs `X-Usage-ApiCalls` (plural) field-name mismatch in `sdks/python/memsy/models.py`. Real bug, but separate from today's shipments; flag as a follow-up.

## Verification

- `npx tsc --noEmit -p tsconfig.json` in `sdks/node` → clean.
- Python smoke confirms `MemoriesResource.list` exposes `actor_id` and `SearchResult.source_metadata` returns the new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
