### PR TITLE
fix(sdk): read X-Usage-* headers as plural names

### DIFF
--- a/sdks/node/src/models.ts
+++ b/sdks/node/src/models.ts
@@ -29,12 +29,12 @@ function parseIntHeader(headers: Headers, name: string): number | null {
 
 export function parseUsageInfo(headers: Headers): UsageInfo {
   return {
-    apiCalls: parseIntHeader(headers, "X-Usage-ApiCall"),
-    apiCallsLimit: parseIntHeader(headers, "X-Usage-ApiCall-Limit"),
+    apiCalls: parseIntHeader(headers, "X-Usage-ApiCalls"),
+    apiCallsLimit: parseIntHeader(headers, "X-Usage-ApiCalls-Limit"),
     eventsIngested: parseIntHeader(headers, "X-Usage-EventsIngested"),
     eventsIngestedLimit: parseIntHeader(headers, "X-Usage-EventsIngested-Limit"),
-    memoryStored: parseIntHeader(headers, "X-Usage-MemoryStored"),
-    memoryStoredLimit: parseIntHeader(headers, "X-Usage-MemoryStored-Limit"),
+    memoryStored: parseIntHeader(headers, "X-Usage-MemoriesStored"),
+    memoryStoredLimit: parseIntHeader(headers, "X-Usage-MemoriesStored-Limit"),
     llmTokens: parseIntHeader(headers, "X-Usage-LlmTokens"),
     llmTokensLimit: parseIntHeader(headers, "X-Usage-LlmTokens-Limit"),
     searchQueries: parseIntHeader(headers, "X-Usage-SearchQueries"),

--- a/sdks/python/memsy/models.py
+++ b/sdks/python/memsy/models.py
@@ -27,12 +27,12 @@ class UsageInfo:
     def from_headers(cls, headers: Mapping[str, str]) -> UsageInfo:
         """Parse usage info from response headers."""
         return cls(
-            api_calls=_parse_int_header(headers, "X-Usage-ApiCall"),
-            api_calls_limit=_parse_int_header(headers, "X-Usage-ApiCall-Limit"),
+            api_calls=_parse_int_header(headers, "X-Usage-ApiCalls"),
+            api_calls_limit=_parse_int_header(headers, "X-Usage-ApiCalls-Limit"),
             events_ingested=_parse_int_header(headers, "X-Usage-EventsIngested"),
             events_ingested_limit=_parse_int_header(headers, "X-Usage-EventsIngested-Limit"),
-            memory_stored=_parse_int_header(headers, "X-Usage-MemoryStored"),
-            memory_stored_limit=_parse_int_header(headers, "X-Usage-MemoryStored-Limit"),
+            memory_stored=_parse_int_header(headers, "X-Usage-MemoriesStored"),
+            memory_stored_limit=_parse_int_header(headers, "X-Usage-MemoriesStored-Limit"),
             llm_tokens=_parse_int_header(headers, "X-Usage-LlmTokens"),
             llm_tokens_limit=_parse_int_header(headers, "X-Usage-LlmTokens-Limit"),
             search_queries=_parse_int_header(headers, "X-Usage-SearchQueries"),


### PR DESCRIPTION
Both SDKs were reading singular header names that the platform never emits, so every consumer was seeing `usage.api_calls = None` and `usage.memory_stored = None` regardless of plan.

## Root cause

`memsy-core/memsy/http/middleware/usage_headers.py` derives header names from `_USAGE_DIMENSIONS = ["api_calls", "events_ingested", "memories_stored", "llm_tokens", "search_queries"]` via the chain:

```python
header_name = "".join(word.capitalize() for word in dim.split("_"))
```

so what the platform actually emits is **plural** for the count fields:

| Header (server) | Old SDK lookup | New SDK lookup |
|---|---|---|
| `X-Usage-ApiCalls` | ❌ `X-Usage-ApiCall` | ✅ `X-Usage-ApiCalls` |
| `X-Usage-ApiCalls-Limit` | ❌ `X-Usage-ApiCall-Limit` | ✅ `X-Usage-ApiCalls-Limit` |
| `X-Usage-MemoriesStored` | ❌ `X-Usage-MemoryStored` | ✅ `X-Usage-MemoriesStored` |
| `X-Usage-MemoriesStored-Limit` | ❌ `X-Usage-MemoryStored-Limit` | ✅ `X-Usage-MemoriesStored-Limit` |
| `X-Usage-EventsIngested[-Limit]` | ✅ | ✅ |
| `X-Usage-LlmTokens[-Limit]` | ✅ | ✅ |
| `X-Usage-SearchQueries[-Limit]` | ✅ | ✅ |

## What changed

- `sdks/python/memsy/models.py::UsageInfo.from_headers` — two header-name fixes.
- `sdks/node/src/models.ts::parseUsageInfo` — same two header-name fixes.

## What did NOT change

Public field names on `UsageInfo` — `api_calls` / `apiCalls` / `memory_stored` / `memoryStored` — stay the same. This is a fix to the wire-read only, not a breaking change to the SDK surface.

## Verification

- **Live verified** against `api-dev.memsy.io`:
  ```
  Before: usage.api_calls = None         usage.memory_stored = None
  After:  usage.api_calls = 235          usage.memory_stored = 380
  ```
- `uv run pytest sdks/python/tests/test_usage_headers.py -v` → 12 pass (the test fixtures were already asserting the plural shape; the parser is finally aligned).
- `npx tsc --noEmit -p sdks/node/tsconfig.json` → clean.