### PR TITLE
docs(ingest): document the closed `kind` enum (BUG-DOC-KIND)

### DIFF
--- a/docs/content/docs/ingesting-events.mdx
+++ b/docs/content/docs/ingesting-events.mdx
@@ -110,6 +110,26 @@ The memory extractor uses the role's and team's `promotion_prompt` to bias extra
 
 Four fields. Everything else is optional.
 
+## Event kinds
+
+`kind` is a closed enum. The API returns `422 Unprocessable Entity` for any other value.
+
+| Value | Use for |
+|---|---|
+| `user_message` | Something the user said or typed. Most common. |
+| `assistant_message` | Something the assistant said back. Useful so the model can recall its own past statements. |
+| `tool_result` | The output of a tool/function call (search result, calculator answer, API response). |
+| `app_event` | App-level signals that aren't a chat turn — e.g. "user changed plan to Pro", "deployment finished". |
+
+If you have a generic CRM event or a webhook payload, `app_event` is almost always the right answer. The extractor still pulls facts and preferences from it, just without conversational framing.
+
+There are no `chat_turn`, `tool_call`, `system`, or `note` kinds. Mapping notes:
+
+- **OpenAI/Anthropic message role `user`** → `user_message`
+- **role `assistant`** → `assistant_message`
+- **role `tool`** (or tool/function response) → `tool_result`
+- **system messages** → don't ingest them; they're rarely worth storing as memory
+
 ## Timestamps
 
 If your events are live, omit `ts` and the server stamps them. If you're **backfilling** historical data, always pass an ISO-8601 timestamp:


### PR DESCRIPTION
## What

Prod smoke test on 2026-05-12 surfaced a DX paper-cut: callers reasonably try `kind: "chat_turn"` (or `"tool_call"`, `"note"`, `"system"`) and get **422 Unprocessable Entity** with nothing in the docs telling them what the valid set actually is.

The runtime enum is `user_message`, `assistant_message`, `tool_result`, `app_event` (see `memsy-core/memsy/core/models.py` `EventKind`). The ingest reference page showed `user_message` in every example but never spelled out the closed set.

## Change

Added an **Event kinds** section to `docs/content/docs/ingesting-events.mdx`, between *The minimum viable event* and *Timestamps*:

- Table of the four valid kinds with one-line guidance on when to use each.
- `app_event` is highlighted as the right answer for generic webhook / CRM payloads that aren't conversational turns.
- Explicit negative list: **no** `chat_turn`, `tool_call`, `system`, or `note`.
- Mapping notes for OpenAI / Anthropic message roles, since that's the most common porting path:
  - role `user` → `user_message`
  - role `assistant` → `assistant_message`
  - role `tool` → `tool_result`
  - system messages — typically don't ingest

20 lines added, no other changes.

## What I deliberately didn't change

**BUG-DOC-METHOD** ("docs show `GET /search` but prod only accepts `POST /search`") — couldn't reproduce. `grep -rn "GET /search"` across `docs/content/` returns nothing; the cURL example on `searching-memory.mdx:30` already shows `POST`. The smoke test likely saw a cached older deployment or a Swagger-generated reference page that isn't under this repo. Marked in the bug tracker as not-reproducible-in-source.

## Out of scope

This PR is independent of `memsy#5` (the broader docs+SDK behaviour-drift sweep) so it can ship on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
