### PR TITLE
docs: clarify threshold score scale + fix /v1/ slip

### DIFF
--- a/docs/content/docs/ingesting-events.mdx
+++ b/docs/content/docs/ingesting-events.mdx
@@ -300,7 +300,7 @@ Recommended batch size: tens to low hundreds. Very large batches (thousands) inc
 
 ## Validation rules
 
-`POST /v1/ingest` returns `422` if any event fails validation:
+`POST /ingest` returns `422` if any event fails validation:
 
 - `content` must contain at least one non-whitespace character and stay under **8000 characters**.
 - `actor_id` and `session_id` must be non-empty after trimming whitespace; both are capped at **256 characters**.

--- a/docs/content/docs/searching-memory.mdx
+++ b/docs/content/docs/searching-memory.mdx
@@ -87,7 +87,15 @@ How many results to return. Memsy may return fewer if not enough pass the thresh
 
 ### `threshold`
 
-A floor on the similarity score. The default `0.3` is a practical starting point — lower to get more results, raise to cut noise. A very high threshold (e.g. `0.8`) returns only near-exact matches.
+A floor on the similarity score — results scoring below it are dropped.
+
+<Warning>
+The SDK default `threshold=0.3` is calibrated for the `0.0`–`1.0` score range you get with reranking on (Growth and above). **On Free tier, reranking is off and raw scores typically sit in the `0.0`–`0.1` range even for strong matches** — so the default `0.3` will return an empty list. Start with `threshold=0.0` (no filtering — rely on `limit` and ranking order) on Free; on Growth+ you can raise it to `0.3`–`0.5` to cut noise.
+</Warning>
+
+The HTTP API itself defaults to `threshold=0.0` (fail-open). The `0.3` default is applied by the Python and Node SDKs.
+
+Scores are not comparable across queries — `0.6` for query A is not the same thing as `0.6` for query B. Treat `threshold` as a relative tuning knob, not an absolute quality bar.
 
 ### `include_source_events` / `includeSourceEvents`
 
@@ -240,10 +248,6 @@ Leave `actor_id`/`actorId` unset and you'll search every actor in the org. Good 
 `search()` always returns a response object. If nothing passed the threshold, `results.results` is `[]`. Handle that case in your UI.
 
 ## Limitations
-
-<Note>
-Scores are not comparable across queries — `0.6` for query A is not the same thing as `0.6` for query B. Use `threshold` relative to the domain, not as an absolute quality bar.
-</Note>
 
 Search only returns memories that have finished processing. Very recent events may still be in the queue — see **[Async Processing](/docs/async-processing)**.
 


### PR DESCRIPTION
## Summary

Three focused doc fixes after auditing live API behavior against the rendered docs.

### 1. Threshold default explanation is misleading on Free tier

The docs say `threshold=0.3` is "a practical starting point", but smoke testing the prod API confirms raw retrieval scores cluster in the **`0.0`–`0.1`** range on Free tier (no reranking). A user copying any quickstart or example verbatim gets `results: []` — the documented default filters out every actual match.

Replaced the prose with a \`<Warning>\` callout explaining:
- SDK default `0.3` is calibrated for the reranked `0.0`–`1.0` score range (Growth+)
- On Free tier, scores sit in `0.0`–`0.1` so `threshold=0.0` is the right starting point
- HTTP API itself defaults to `0.0` (fail-open); only the SDKs apply `0.3`

### 2. Consolidated score-comparability caveat

The "scores not comparable across queries" note was duplicated under \`Limitations\`. Moved it next to the threshold prose where readers will actually see it when deciding how to set the value, and removed the duplicate.

### 3. \`/v1/\` slip in ingest validation section

\`ingesting-events.mdx\` referred to the endpoint as \`POST /v1/ingest\` once in the Validation rules section. Everywhere else uses \`$MEMSY_BASE_URL/ingest\` (the base URL handles versioning). Dropped the prefix for consistency.

## Files

- \`docs/content/docs/searching-memory.mdx\` — threshold prose rewrite + consolidated note (fixes 1 + 2)
- \`docs/content/docs/ingesting-events.mdx\` — one-char slip fix (fix 3)

## Out of scope (deferred)

- The 401/403 discrepancy in \`error-handling.mdx\` where prod's API Gateway returns 403 but docs say 401. Will tackle separately.
- Lowering the SDK default to `0.0` (a code change in \`memsy/sdks/python\` and \`memsy/sdks/node\`) — separate PR if we want to truly fix the trap at the SDK layer rather than warn around it.
- Normalizing scores in memsy-core to \`0.0\`–\`1.0\` regardless of reranking state — a memsy-core change.

## Test plan

- [ ] \`pnpm dev\` (or whichever) in \`docs/\`, navigate to \`/docs/searching-memory\`, confirm the \`<Warning>\` renders with the existing site style
- [ ] Confirm the Limitations section no longer has the duplicate Note
- [ ] Navigate to \`/docs/ingesting-events\` → Validation rules section, confirm \`POST /ingest\` (not \`/v1/ingest\`)