### PR TITLE
feat(sdk): lower search threshold default from 0.3 to 0.0

### DIFF
--- a/docs/content/docs/ingesting-events.mdx
+++ b/docs/content/docs/ingesting-events.mdx
@@ -300,7 +300,7 @@ Recommended batch size: tens to low hundreds. Very large batches (thousands) inc
 
 ## Validation rules
 
-`POST /v1/ingest` returns `422` if any event fails validation:
+`POST /ingest` returns `422` if any event fails validation:
 
 - `content` must contain at least one non-whitespace character and stay under **8000 characters**.
 - `actor_id` and `session_id` must be non-empty after trimming whitespace; both are capped at **256 characters**.

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -180,7 +180,7 @@ Five minutes to your first memory. This page walks you through **dashboard → i
             "query": "user preferences",
             "actor_id": "user_42",
             "limit": 10,
-            "threshold": 0.3
+            "threshold": 0.0
           }'
         ```
       </Tab>

--- a/docs/content/docs/reference/node/memsy-client.mdx
+++ b/docs/content/docs/reference/node/memsy-client.mdx
@@ -74,7 +74,7 @@ search(query: string, options?: SearchOptions): Promise<SearchResponse>
 |----------------------|-----------|---------|--------------------------------------------------------------|
 | `actorId`            | `string`  | —       | Restrict search to a specific actor.                         |
 | `limit`              | `number`  | `10`    | Max results to return.                                       |
-| `threshold`          | `number`  | `0.3`   | Minimum similarity score (0.0–1.0).                          |
+| `threshold`          | `number`  | `0.0`   | Minimum similarity score. `0.0` = no filter (rely on `limit`). Raw scores cluster in `0.0`–`0.1` without reranking; with reranking on (Pro+) scores are normalised to `0.0`–`1.0` and `0.3` becomes meaningful. |
 | `includeSourceEvents`| `boolean` | `false` | Include the originating events alongside each memory.        |
 
 ```ts

--- a/docs/content/docs/reference/node/memsy-client.mdx
+++ b/docs/content/docs/reference/node/memsy-client.mdx
@@ -74,7 +74,7 @@ search(query: string, options?: SearchOptions): Promise<SearchResponse>
 |----------------------|-----------|---------|--------------------------------------------------------------|
 | `actorId`            | `string`  | —       | Restrict search to a specific actor.                         |
 | `limit`              | `number`  | `10`    | Max results to return.                                       |
-| `threshold`          | `number`  | `0.0`   | Minimum similarity score. `0.0` = no filter (rely on `limit`). Raw scores cluster in `0.0`–`0.1` without reranking; with reranking on (Pro+) scores are normalised to `0.0`–`1.0` and `0.3` becomes meaningful. |
+| `threshold`          | `number`  | `0.0`   | Minimum similarity score. `0.0` = no filter. See [Threshold guidance](/docs/searching-memory#threshold). |
 | `includeSourceEvents`| `boolean` | `false` | Include the originating events alongside each memory.        |
 
 ```ts

--- a/docs/content/docs/reference/python/memsy-client.mdx
+++ b/docs/content/docs/reference/python/memsy-client.mdx
@@ -66,7 +66,7 @@ search(
     *,
     actor_id: str | None = None,
     limit: int = 10,
-    threshold: float = 0.3,
+    threshold: float = 0.0,
     include_source_events: bool = False,
 ) -> SearchResponse
 ```
@@ -76,7 +76,7 @@ search(
 | `query` | `str` | — | Natural-language query. |
 | `actor_id` | `str \| None` | `None` | Filter results to a single actor. |
 | `limit` | `int` | `10` | Maximum number of results. |
-| `threshold` | `float` | `0.3` | Minimum similarity score. |
+| `threshold` | `float` | `0.0` | Minimum similarity score. `0.0` = no filter (rely on `limit`). Raw scores cluster in `0.0`–`0.1` without reranking; with reranking enabled (Pro and above) scores are normalised to `0.0`–`1.0` and `0.3` becomes meaningful. |
 | `include_source_events` | `bool` | `False` | Include source events in each result. |
 
 **Returns**: `SearchResponse` with `results: list[SearchResult]`, plus optional `usage` / `rate_limit`.

--- a/docs/content/docs/reference/python/memsy-client.mdx
+++ b/docs/content/docs/reference/python/memsy-client.mdx
@@ -76,7 +76,7 @@ search(
 | `query` | `str` | — | Natural-language query. |
 | `actor_id` | `str \| None` | `None` | Filter results to a single actor. |
 | `limit` | `int` | `10` | Maximum number of results. |
-| `threshold` | `float` | `0.0` | Minimum similarity score. `0.0` = no filter (rely on `limit`). Raw scores cluster in `0.0`–`0.1` without reranking; with reranking enabled (Pro and above) scores are normalised to `0.0`–`1.0` and `0.3` becomes meaningful. |
+| `threshold` | `float` | `0.0` | Minimum similarity score. `0.0` = no filter. See [Threshold guidance](/docs/searching-memory#threshold). |
 | `include_source_events` | `bool` | `False` | Include source events in each result. |
 
 **Returns**: `SearchResponse` with `results: list[SearchResult]`, plus optional `usage` / `rate_limit`.

--- a/docs/content/docs/searching-memory.mdx
+++ b/docs/content/docs/searching-memory.mdx
@@ -45,7 +45,7 @@ description: Natural-language queries, thresholds, scoping, and score interpreta
         *,
         actor_id=None,                      # optional — filter to one actor
         limit=10,                           # max results (default 10)
-        threshold=0.0,                      # minimum similarity score (default 0.0 — no filter)
+        threshold=0.0,                      # minimum similarity (default 0.0)
         include_source_events=False,        # attach source events to results
     )
     ```
@@ -55,7 +55,7 @@ description: Natural-language queries, thresholds, scoping, and score interpreta
     client.search(query, {
       actorId,                  // optional — filter to one actor
       limit: 10,                // max results (default 10)
-      threshold: 0.0,           // minimum similarity score (default 0.0 — no filter)
+      threshold: 0.0,           // minimum similarity (default 0.0)
       includeSourceEvents: false,
     });
     ```
@@ -91,7 +91,7 @@ A floor on the similarity score — results scoring below it are dropped. **The 
 
 Raise the threshold to cut noise. The right value depends on tier:
 
-- **Free / Pro starter (no reranking)**: raw retrieval scores cluster in `0.0`–`0.1` even for strong matches. Stay near `0.0`–`0.05`.
+- **Free (no reranking)**: raw retrieval scores cluster in `0.0`–`0.1` even for strong matches. Stay near `0.0`–`0.05`.
 - **Pro and above (with Cohere reranking)**: scores are normalised to `0.0`–`1.0`. A threshold around `0.3`–`0.5` becomes a meaningful "good match" floor; `0.8`+ returns only near-exact matches.
 
 Scores are not comparable across queries — `0.6` for query A is not the same thing as `0.6` for query B. Treat `threshold` as a relative tuning knob, not an absolute quality bar.

--- a/docs/content/docs/searching-memory.mdx
+++ b/docs/content/docs/searching-memory.mdx
@@ -45,7 +45,7 @@ description: Natural-language queries, thresholds, scoping, and score interpreta
         *,
         actor_id=None,                      # optional — filter to one actor
         limit=10,                           # max results (default 10)
-        threshold=0.3,                      # minimum similarity (0.0–1.0)
+        threshold=0.0,                      # minimum similarity score (default 0.0 — no filter)
         include_source_events=False,        # attach source events to results
     )
     ```
@@ -55,7 +55,7 @@ description: Natural-language queries, thresholds, scoping, and score interpreta
     client.search(query, {
       actorId,                  // optional — filter to one actor
       limit: 10,                // max results (default 10)
-      threshold: 0.3,           // minimum similarity (0.0–1.0)
+      threshold: 0.0,           // minimum similarity score (default 0.0 — no filter)
       includeSourceEvents: false,
     });
     ```
@@ -66,7 +66,7 @@ description: Natural-language queries, thresholds, scoping, and score interpreta
       "query": "natural language",
       "actor_id": "user_42",
       "limit": 10,
-      "threshold": 0.3,
+      "threshold": 0.0,
       "include_source_events": false
     }
     ```
@@ -87,7 +87,14 @@ How many results to return. Memsy may return fewer if not enough pass the thresh
 
 ### `threshold`
 
-A floor on the similarity score. The default `0.3` is a practical starting point — lower to get more results, raise to cut noise. A very high threshold (e.g. `0.8`) returns only near-exact matches.
+A floor on the similarity score — results scoring below it are dropped. **The SDK default is `0.0` (no filter)**, so out of the box you get the top `limit` results ranked by relevance.
+
+Raise the threshold to cut noise. The right value depends on tier:
+
+- **Free / Pro starter (no reranking)**: raw retrieval scores cluster in `0.0`–`0.1` even for strong matches. Stay near `0.0`–`0.05`.
+- **Pro and above (with Cohere reranking)**: scores are normalised to `0.0`–`1.0`. A threshold around `0.3`–`0.5` becomes a meaningful "good match" floor; `0.8`+ returns only near-exact matches.
+
+Scores are not comparable across queries — `0.6` for query A is not the same thing as `0.6` for query B. Treat `threshold` as a relative tuning knob, not an absolute quality bar.
 
 ### `include_source_events` / `includeSourceEvents`
 
@@ -240,10 +247,6 @@ Leave `actor_id`/`actorId` unset and you'll search every actor in the org. Good 
 `search()` always returns a response object. If nothing passed the threshold, `results.results` is `[]`. Handle that case in your UI.
 
 ## Limitations
-
-<Note>
-Scores are not comparable across queries — `0.6` for query A is not the same thing as `0.6` for query B. Use `threshold` relative to the domain, not as an absolute quality bar.
-</Note>
 
 Search only returns memories that have finished processing. Very recent events may still be in the queue — see **[Async Processing](/docs/async-processing)**.
 

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -20,6 +20,10 @@ export type MemsyClientOptions = BaseClientOptions;
 export interface SearchOptions {
   actorId?: string;
   limit?: number;
+  /**
+   * Minimum relevance score. Default `0.0` (no filter).
+   * See https://docs.memsy.io/docs/searching-memory#threshold for tier-specific guidance.
+   */
   threshold?: number;
   includeSourceEvents?: boolean;
 }
@@ -57,10 +61,6 @@ export class MemsyClient extends BaseHttpClient {
   }
 
   async search(query: string, options: SearchOptions = {}): Promise<SearchResponse> {
-    // threshold defaults to 0.0 (no filter). Raw retrieval scores cluster
-    // in 0.0–0.1 on tiers without reranking; with reranking on (Pro+)
-    // scores are normalised to 0.0–1.0 and a threshold around 0.3 becomes
-    // meaningful. Scores are not comparable across queries.
     const body: Record<string, unknown> = {
       query,
       limit: options.limit ?? 10,

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -57,10 +57,14 @@ export class MemsyClient extends BaseHttpClient {
   }
 
   async search(query: string, options: SearchOptions = {}): Promise<SearchResponse> {
+    // threshold defaults to 0.0 (no filter). Raw retrieval scores cluster
+    // in 0.0–0.1 on tiers without reranking; with reranking on (Pro+)
+    // scores are normalised to 0.0–1.0 and a threshold around 0.3 becomes
+    // meaningful. Scores are not comparable across queries.
     const body: Record<string, unknown> = {
       query,
       limit: options.limit ?? 10,
-      threshold: options.threshold ?? 0.3,
+      threshold: options.threshold ?? 0.0,
       include_source_events: options.includeSourceEvents ?? false,
     };
     if (options.actorId !== undefined) body.actor_id = options.actorId;

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -113,7 +113,7 @@ results = client.search(
     query="what does the user prefer?",
     actor_id="user_1",            # optional — scope to a specific user
     limit=10,                     # default: 10
-    threshold=0.3,                # minimum relevance score, default: 0.3
+    threshold=0.0,                # minimum relevance score, default: 0.0 (no filter)
     include_source_events=True,   # attach source events to each result
 )
 

--- a/sdks/python/memsy/async_client.py
+++ b/sdks/python/memsy/async_client.py
@@ -147,11 +147,8 @@ class AsyncMemsyClient(HttpCoreMixin):
         :param actor_id: Optional actor/user ID to further scope the search.
         :param limit: Maximum number of results to return (default 10).
         :param threshold: Minimum relevance score (default 0.0 — no filter).
-            Raw retrieval scores cluster in 0.0–0.1 on tiers without
-            reranking; with reranking enabled (Pro and above) scores
-            are normalised to 0.0–1.0 and a threshold around 0.3 becomes
-            meaningful. Scores are also not comparable across queries —
-            treat this as a relative tuning knob.
+            See https://docs.memsy.io/docs/searching-memory#threshold for
+            tier-specific guidance.
         :param include_source_events: Include source events in result metadata.
         :returns: SearchResponse containing ranked memory results.
         """

--- a/sdks/python/memsy/async_client.py
+++ b/sdks/python/memsy/async_client.py
@@ -137,7 +137,7 @@ class AsyncMemsyClient(HttpCoreMixin):
         *,
         actor_id: str | None = None,
         limit: int = 10,
-        threshold: float = 0.3,
+        threshold: float = 0.0,
         include_source_events: bool = False,
     ) -> SearchResponse:
         """
@@ -146,7 +146,12 @@ class AsyncMemsyClient(HttpCoreMixin):
         :param query: Natural language query string.
         :param actor_id: Optional actor/user ID to further scope the search.
         :param limit: Maximum number of results to return (default 10).
-        :param threshold: Minimum relevance score threshold (default 0.3).
+        :param threshold: Minimum relevance score (default 0.0 — no filter).
+            Raw retrieval scores cluster in 0.0–0.1 on tiers without
+            reranking; with reranking enabled (Pro and above) scores
+            are normalised to 0.0–1.0 and a threshold around 0.3 becomes
+            meaningful. Scores are also not comparable across queries —
+            treat this as a relative tuning knob.
         :param include_source_events: Include source events in result metadata.
         :returns: SearchResponse containing ranked memory results.
         """

--- a/sdks/python/memsy/client.py
+++ b/sdks/python/memsy/client.py
@@ -139,7 +139,7 @@ class MemsyClient(HttpCoreMixin):
         *,
         actor_id: str | None = None,
         limit: int = 10,
-        threshold: float = 0.3,
+        threshold: float = 0.0,
         include_source_events: bool = False,
     ) -> SearchResponse:
         """
@@ -148,7 +148,12 @@ class MemsyClient(HttpCoreMixin):
         :param query: Natural language query string.
         :param actor_id: Optional actor/user ID to further scope the search.
         :param limit: Maximum number of results to return (default 10).
-        :param threshold: Minimum relevance score threshold (default 0.3).
+        :param threshold: Minimum relevance score (default 0.0 — no filter).
+            Raw retrieval scores cluster in 0.0–0.1 on tiers without
+            reranking; with reranking enabled (Pro and above) scores
+            are normalised to 0.0–1.0 and a threshold around 0.3 becomes
+            meaningful. Scores are also not comparable across queries —
+            treat this as a relative tuning knob.
         :param include_source_events: Include source events in result metadata.
         :returns: SearchResponse containing ranked memory results.
         """

--- a/sdks/python/memsy/client.py
+++ b/sdks/python/memsy/client.py
@@ -149,11 +149,8 @@ class MemsyClient(HttpCoreMixin):
         :param actor_id: Optional actor/user ID to further scope the search.
         :param limit: Maximum number of results to return (default 10).
         :param threshold: Minimum relevance score (default 0.0 — no filter).
-            Raw retrieval scores cluster in 0.0–0.1 on tiers without
-            reranking; with reranking enabled (Pro and above) scores
-            are normalised to 0.0–1.0 and a threshold around 0.3 becomes
-            meaningful. Scores are also not comparable across queries —
-            treat this as a relative tuning knob.
+            See https://docs.memsy.io/docs/searching-memory#threshold for
+            tier-specific guidance.
         :param include_source_events: Include source events in result metadata.
         :returns: SearchResponse containing ranked memory results.
         """


### PR DESCRIPTION
## Summary

Single-PR landing for the threshold/score-scale issue. Combines two earlier proposals:

- **Real fix**: lower the SDK `search()` default `threshold` from `0.3` to `0.0` so users on Free / Pro starter (no reranking) get results out of the box.
- **Doc cleanup** (folded in from #8): rewrite the threshold prose to explain the tier-dependent score scale, consolidate the duplicated "scores not comparable across queries" note, and fix a stray `POST /v1/ingest` → `POST /ingest` slip in the Validation rules section.

PR #8 has been closed in favor of this one.

## Why the old default was a footgun

- `0.3` was calibrated for the `0.0`–`1.0` score range produced by Cohere reranking
- Reranking is only available from the **Pro plan and above**
- On Free / Pro starter, raw retrieval scores cluster in **`0.0`–`0.1`** even for the strongest matches
- So new users copying the quickstart got `results: []` with no signal as to why — the documented "sensible default" silently dropped every real result

## After this change

- `client.search("...")` returns the top `limit` results ranked by relevance — no surprise filtering
- Users still pass `threshold=0.3` (or higher) explicitly once they're on Pro+ and understand their score scale
- Docs explain when each value is sensible

## Files touched (9)

**SDK code:**
- `sdks/python/memsy/client.py` — `MemsyClient.search` default `0.3` → `0.0` + tier-aware docstring
- `sdks/python/memsy/async_client.py` — same for `AsyncMemsyClient.search`
- `sdks/node/src/client.ts` — `?? 0.3` → `?? 0.0` + comment explaining the score scale

**Docs:**
- `sdks/python/README.md` — search example default
- `docs/content/docs/reference/python/memsy-client.mdx` — signature + parameter table
- `docs/content/docs/reference/node/memsy-client.mdx` — SearchOptions table
- `docs/content/docs/searching-memory.mdx` — Parameters tabs (Python, Node, cURL) + rewritten threshold prose (Free/Pro-starter: `0.0`–`0.05`; Pro+: `0.3`–`0.5`) + consolidated comparability note (no more duplicate in Limitations)
- `docs/content/docs/quickstart.mdx` — cURL example threshold
- `docs/content/docs/ingesting-events.mdx` — stray `/v1/ingest` → `/ingest` (folded from #8)

## Backward-compat note

This is a default-value change — technically backward-incompatible for callers relying on the implicit `0.3` filter. After this lands:
- Existing callers without explicit `threshold` see **more results** than before (more noise on Free / Pro starter; same ranking order).
- The semantic meaning of `results.results[i].score` is unchanged.
- Callers passing `threshold=` explicitly are unaffected.
- HTTP API behaviour is unchanged — it already defaulted to `0.0`.

Worth a minor SDK version bump on release.

## Test plan

- [ ] `cd sdks/python && uv run pytest tests/` — Python SDK tests pass (none assert on the default value)
- [ ] Node SDK tests pass
- [ ] `pnpm dev` in `docs/`, navigate to `/docs/searching-memory`, `/docs/reference/python/memsy-client`, `/docs/reference/node/memsy-client`, `/docs/ingesting-events#validation-rules` — confirm new defaults and tier-aware prose render correctly
- [ ] Smoke-test against prod: a fresh ingest + `client.search("…")` with no explicit threshold returns the just-ingested memory on a Free-tier org (the regression scenario the old default produced)