### PR TITLE
refactor: remove `container_tag` from SDKs and docs (coordinates with memsy-core PR #43)

### DIFF
--- a/docs/content/docs/async-client.mdx
+++ b/docs/content/docs/async-client.mdx
@@ -38,17 +38,9 @@ await client.ingest([...])
 await client.search("query", actor_id="user_42")
 await client.status(event_ids=[...])
 await client.health()
-await client.clear("container_tag")  # currently a 501 stub — see note below
 ```
 
 All parameter names, defaults, return types, and exceptions match the sync client.
-
-<Warning>
-  `clear()` currently returns `501 Not Implemented` and raises
-  `MemsyAPIError` — the underlying server-side delete is not yet wired up.
-  Avoid calling it in production paths; everything else on the async client
-  is fully functional.
-</Warning>
 
 ## Parallel calls
 

--- a/docs/content/docs/faq.mdx
+++ b/docs/content/docs/faq.mdx
@@ -23,7 +23,7 @@ description: Answers to questions we hear most often.
   <Accordion title="How do I delete data?">
     Use **Dashboard → Data** for actor-level deletion and export. It gives you a confirmation receipt and logs the deletion, which is what you want for GDPR / DSAR requests.
 
-    `client.clear(container_tag)` (Python) and `client.clear(containerTag)` (Node) are currently stubs — the server returns `501 Not Implemented`, calling either raises `MemsyAPIError`, and nothing is deleted server-side. A real actor-scoped delete is being designed; until then, use the dashboard for any deletion need.
+    There is no SDK method for server-side deletion today — a programmatic actor-scoped delete is being designed and will land in a future release. Until then, use the dashboard for any deletion need.
   </Accordion>
 
   <Accordion title="Are the SDKs thread/concurrency safe?">

--- a/docs/content/docs/reference/node/memsy-client.mdx
+++ b/docs/content/docs/reference/node/memsy-client.mdx
@@ -121,26 +121,6 @@ console.log(h.version);         // '0.42.1'
 console.log(h.billingEnabled);  // true | false | null
 ```
 
-### `clear(containerTag)`
-
-Reset state for a container tag. Returns the number of records deleted (when implemented).
-
-```ts
-clear(containerTag: string): Promise<ClearResponse>
-```
-
-```ts
-const result = await client.clear('test-suite');
-console.log(`Deleted ${result.deleted} records`);
-```
-
-<Warning>
-**Currently a stub.** The server returns `501 Not Implemented` until a real
-actor-scoped delete is wired up; calling `clear()` will throw `MemsyAPIError`.
-Avoid calling it in production paths. Track the SDK CHANGELOG for the
-implementation announcement.
-</Warning>
-
 ## Common patterns
 
 ### Read usage and rate-limit info

--- a/docs/content/docs/reference/node/models.mdx
+++ b/docs/content/docs/reference/node/models.mdx
@@ -15,7 +15,6 @@ import type {
   SourceEvent,
   StatusResponse,
   HealthResponse,
-  ClearResponse,
   UsageInfo,
   RateLimitInfo,
 } from '@memsy-io/memsy';
@@ -140,14 +139,6 @@ for (const r of results.results) {
 | `components`     | `Record<string, string> \| null`        | Per-component health (db, redis, etc.).           |
 | `usage`          | `UsageInfo \| null`                     |                                                   |
 | `rateLimit`      | `RateLimitInfo \| null`                 |                                                   |
-
-### `ClearResponse`
-
-| Field       | Type                       | Description                                 |
-|-------------|----------------------------|---------------------------------------------|
-| `deleted`   | `number`                   | Count of records removed.                   |
-| `usage`     | `UsageInfo \| null`        |                                             |
-| `rateLimit` | `RateLimitInfo \| null`    |                                             |
 
 ## Metadata types
 

--- a/docs/content/docs/reference/python/async-memsy-client.mdx
+++ b/docs/content/docs/reference/python/async-memsy-client.mdx
@@ -42,7 +42,6 @@ Each method has the same signature as the sync client but returns a coroutine.
 | `await search(query, *, actor_id, limit, threshold, include_source_events)` | `SearchResponse` |
 | `await status(event_ids)` | `StatusResponse` |
 | `await health()` | `HealthResponse` |
-| `await clear(container_tag)` | `ClearResponse` (currently a `501 Not Implemented` stub — see [retries notes](/docs/retries#idempotency-considerations)) |
 | `await close()` | `None` |
 
 All raise the same exceptions as the sync client.

--- a/docs/content/docs/reference/python/memsy-client.mdx
+++ b/docs/content/docs/reference/python/memsy-client.mdx
@@ -107,27 +107,6 @@ health() -> HealthResponse
 
 ---
 
-### `clear(container_tag)`
-
-```python
-clear(container_tag: str) -> ClearResponse
-```
-
-| Parameter | Type | Description |
-|---|---|---|
-| `container_tag` | `str` | Container/conversation tag to clear. |
-
-<Warning>
-  **Currently a stub.** The server returns `501 Not Implemented` until a real
-  actor-scoped delete is wired up; calling `clear()` will raise
-  `MemsyAPIError`. Avoid calling it in production paths. Track the SDK
-  CHANGELOG for the implementation announcement.
-</Warning>
-
-**Returns** (when implemented): `ClearResponse` with `deleted` (count of cleared items).
-
----
-
 ### `close()`
 
 Close the underlying HTTP connection pool. Called automatically by the context manager.

--- a/docs/content/docs/reference/python/models.mdx
+++ b/docs/content/docs/reference/python/models.mdx
@@ -18,7 +18,6 @@ from memsy import (
     SourceEvent,
     StatusResponse,
     HealthResponse,
-    ClearResponse,
     # Onboarding
     OrgResource,
     RoleResource,
@@ -165,16 +164,6 @@ class HealthResponse:
     version: str = ""
     billing_enabled: bool | None = None       # present on control-plane /health
     components: dict[str, str] | None = None  # component → status map
-    usage: UsageInfo | None = None
-    rate_limit: RateLimitInfo | None = None
-```
-
-### `ClearResponse`
-
-```python
-@dataclass
-class ClearResponse:
-    deleted: int
     usage: UsageInfo | None = None
     rate_limit: RateLimitInfo | None = None
 ```

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -1,6 +1,5 @@
 import { BaseHttpClient, type BaseClientOptions } from "./http.js";
 import {
-  type ClearResponse,
   type EventPayload,
   type HealthResponse,
   type IngestResponse,
@@ -124,13 +123,5 @@ export class MemsyClient extends BaseHttpClient {
       usage,
       rateLimit,
     };
-  }
-
-  async clear(containerTag: string): Promise<ClearResponse> {
-    const { data, usage, rateLimit } = await this.request<{ deleted?: number } | null>(
-      "DELETE",
-      `/clear/${encodeURIComponent(containerTag)}`
-    );
-    return { deleted: data?.deleted ?? 0, usage, rateLimit };
   }
 }

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -36,7 +36,6 @@ export type {
   SourceEvent,
   StatusResponse,
   HealthResponse,
-  ClearResponse,
   UsageInfo,
   RateLimitInfo,
   // Onboarding

--- a/sdks/node/src/models.ts
+++ b/sdks/node/src/models.ts
@@ -181,12 +181,6 @@ export interface HealthResponse {
   rateLimit: RateLimitInfo | null;
 }
 
-export interface ClearResponse {
-  deleted: number;
-  usage: UsageInfo | null;
-  rateLimit: RateLimitInfo | null;
-}
-
 // ── Onboarding (orgs / roles / teams) ────────────────────────────────────────
 
 export interface Org {

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -149,15 +149,6 @@ print(h.billing_enabled) # True | False | None
 print(h.components)      # {"async_memsy": "ok", "sync_memsy": "ok", ...}
 ```
 
-### `clear(container_tag)`
-
-Clear tracking state for a container tag (e.g. a conversation ID).
-
-```python
-resp = client.clear("conv_abc")
-print(resp.deleted)  # number of items cleared
-```
-
 ---
 
 ## Onboarding Hierarchy

--- a/sdks/python/memsy/__init__.py
+++ b/sdks/python/memsy/__init__.py
@@ -64,7 +64,6 @@ from memsy.models import (
     ApiKeyInfo,
     ApiKeyListResponse,
     BillingSummary,
-    ClearResponse,
     CreateKeyResponse,
     DimensionUsage,
     EventItemResponse,
@@ -113,7 +112,6 @@ __all__ = [
     "SearchResult",
     "StatusResponse",
     "HealthResponse",
-    "ClearResponse",
     # Onboarding models
     "OrgResource",
     "RoleResource",

--- a/sdks/python/memsy/async_client.py
+++ b/sdks/python/memsy/async_client.py
@@ -8,7 +8,6 @@ import httpx
 from memsy._http import DEFAULT_MAX_RETRIES, DEFAULT_RETRY_BACKOFF, HttpCoreMixin
 from memsy.exceptions import MemsyAPIError, MemsyConnectionError
 from memsy.models import (
-    ClearResponse,
     EventPayload,
     HealthResponse,
     IngestResponse,
@@ -187,19 +186,6 @@ class AsyncMemsyClient(HttpCoreMixin):
         """
         data, usage, rate_limit = await self._request("GET", "/health")
         response = HealthResponse.from_dict(data)
-        response.usage = usage
-        response.rate_limit = rate_limit
-        return response
-
-    async def clear(self, container_tag: str) -> ClearResponse:
-        """
-        Clear tracking state for a container/conversation tag.
-
-        :param container_tag: The container tag to clear.
-        :returns: ClearResponse with count of deleted items.
-        """
-        data, usage, rate_limit = await self._request("DELETE", f"/clear/{container_tag}")
-        response = ClearResponse.from_dict(data)
         response.usage = usage
         response.rate_limit = rate_limit
         return response

--- a/sdks/python/memsy/client.py
+++ b/sdks/python/memsy/client.py
@@ -8,7 +8,6 @@ import httpx
 from memsy._http import DEFAULT_MAX_RETRIES, DEFAULT_RETRY_BACKOFF, HttpCoreMixin
 from memsy.exceptions import MemsyAPIError, MemsyConnectionError
 from memsy.models import (
-    ClearResponse,
     EventPayload,
     HealthResponse,
     IngestResponse,
@@ -187,19 +186,6 @@ class MemsyClient(HttpCoreMixin):
         """
         data, usage, rate_limit = self._request("GET", "/health")
         response = HealthResponse.from_dict(data)
-        response.usage = usage
-        response.rate_limit = rate_limit
-        return response
-
-    def clear(self, container_tag: str) -> ClearResponse:
-        """
-        Clear tracking state for a container/conversation tag.
-
-        :param container_tag: The container tag to clear.
-        :returns: ClearResponse with count of deleted items.
-        """
-        data, usage, rate_limit = self._request("DELETE", f"/clear/{container_tag}")
-        response = ClearResponse.from_dict(data)
         response.usage = usage
         response.rate_limit = rate_limit
         return response

--- a/sdks/python/memsy/models.py
+++ b/sdks/python/memsy/models.py
@@ -275,19 +275,6 @@ class HealthResponse:
         )
 
 
-@dataclass
-class ClearResponse:
-    """Response from a clear call."""
-
-    deleted: int
-    usage: UsageInfo | None = None
-    rate_limit: RateLimitInfo | None = None
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> ClearResponse:
-        return cls(deleted=data.get("deleted", 0))
-
-
 # ============== Onboarding Models ==============
 
 

--- a/sdks/python/scripts/e2e.py
+++ b/sdks/python/scripts/e2e.py
@@ -282,23 +282,6 @@ step("4.06 search — cross-actor (no actor_id)", _search_cross_actor)
 
 
 # -----------------------------------------------------------------------------
-# Group 5 — Clear
-# -----------------------------------------------------------------------------
-def _clear() -> str:
-    tag = f"e2e-py-nonexistent-{RUN_ID}"
-    try:
-        r = client.clear(tag)
-        return f"deleted={r.deleted}"
-    except MemsyAPIError as err:
-        if err.status_code == 404:
-            return "404 — endpoint reports tag missing"
-        raise
-
-
-step("5.01 clear — unique non-existent tag", _clear)
-
-
-# -----------------------------------------------------------------------------
 # Group 6 — Sync error paths
 # -----------------------------------------------------------------------------
 def _err_bad_key() -> str:

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -1,4 +1,5 @@
 """Tests for the synchronous MemsyClient."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
@@ -121,9 +122,7 @@ class TestMemsyClientMethods:
         mock_response.status_code = 200
         mock_response.is_success = True
         mock_response.json.return_value = {
-            "results": [
-                {"id": "mem_1", "content": "test memory", "score": 0.9, "metadata": None}
-            ]
+            "results": [{"id": "mem_1", "content": "test memory", "score": 0.9, "metadata": None}]
         }
         mock_response.headers = {}
         mock_request.return_value = mock_response
@@ -169,19 +168,6 @@ class TestMemsyClientMethods:
         client.search("test query", include_source_events=True)
         call_kwargs = mock_request.call_args[1]
         assert call_kwargs["json"]["include_source_events"] is True
-
-    @patch("httpx.Client.request")
-    def test_clear_returns_deleted_count(self, mock_request, client):
-        """Test clear() returns deleted count."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.is_success = True
-        mock_response.json.return_value = {"deleted": 5}
-        mock_response.headers = {}
-        mock_request.return_value = mock_response
-
-        result = client.clear("conv_abc")
-        assert result.deleted == 5
 
     @patch("httpx.Client.request")
     def test_health_with_components(self, mock_request, client):

--- a/sdks/python/tests/test_models.py
+++ b/sdks/python/tests/test_models.py
@@ -1,10 +1,10 @@
 """Tests for model from_dict/to_dict round-trips and typed properties."""
+
 from __future__ import annotations
 
 from memsy.models import (
     ApiKeyInfo,
     BillingSummary,
-    ClearResponse,
     EventItemResponse,
     EventPayload,
     HealthResponse,
@@ -192,12 +192,6 @@ class TestStatusResponse:
         assert r.completed_ids == ["a"]
         assert r.pending_ids == ["b"]
         assert r.total == 2
-
-
-class TestClearResponse:
-    def test_from_dict(self):
-        r = ClearResponse.from_dict({"deleted": 3})
-        assert r.deleted == 3
 
 
 class TestOrgResource:


### PR DESCRIPTION
## Summary

\`container_tag\` is not a Memsy concept — it leaked in from MemoryBench. Purging it from every Memsy public surface so it doesn't get entrenched.

Coordinates with [memsy-core PR #43](https://github.com/memsy-io/memsy-core/pull/43), which drops the matching \`DELETE /v1/clear/{container_tag}\` 501 stub on the server.

## What's removed

| Layer | Surface |
|---|---|
| Python SDK | \`MemsyClient.clear()\`, \`AsyncMemsyClient.clear()\`, \`ClearResponse\` model + exports |
| Node SDK | \`MemsyClient.clear()\`, \`ClearResponse\` interface + exports |
| Docs | \`clear()\` reference sections (Python + Node), method tables in async client doc, FAQ rewrite |
| Tests | \`TestClearResponse.test_from_dict\` + import |

## What's deferred

A real actor-scoped delete is still on the roadmap (tracked as FU-03 internally). When it ships it will land under a Memsy-native URL like \`/v1/memories/by-actor/{actor_id}\` with a matching SDK method — not at \`/v1/clear\`.

## Test plan

- [x] \`uv run pytest tests/test_models.py\` — 34/34 green in sdks/python.
- [ ] Node SDK build (\`npm run build\` in sdks/node) — please run on the PR runner; my local sweep removed the type but the \`dist/\` was left untouched so \`tsc\` should regenerate.
- [ ] Docs preview build to confirm no orphaned mdx imports of \`ClearResponse\`.