### PR TITLE
Add promoted role/team-scoped memory retrieval support in SDKs

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memsy-io/memsy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Official Node.js SDK for the Memsy memory service",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memsy-io/memsy",
-  "version": "0.1.2",
+  "version": "0.3.2",
   "description": "Official Node.js SDK for the Memsy memory service",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -30,6 +30,8 @@ export interface SearchOptions {
    */
   threshold?: number;
   includeSourceEvents?: boolean;
+  roleIds?: string[];
+  teamIds?: string[];
 }
 
 /**
@@ -72,6 +74,8 @@ export class MemsyClient extends BaseHttpClient {
       include_source_events: options.includeSourceEvents ?? false,
     };
     if (options.actorId !== undefined) body.actor_id = options.actorId;
+    if (options.roleIds?.length) body.role_ids = options.roleIds;
+    if (options.teamIds?.length) body.team_ids = options.teamIds;
 
     const { data, usage, rateLimit } = await this.request<{
       results: Array<{

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -34,6 +34,7 @@ export type {
   SearchResponse,
   SearchResult,
   SourceEvent,
+  SourceMetadata,
   StatusResponse,
   HealthResponse,
   UsageInfo,

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.2] - 2026-05-18
+
+### Added
+- `role_ids` and `team_ids` params on `search()` for hierarchical recall via role/team-promoted memories
+
 
 ### Changed
 

--- a/sdks/python/memsy/async_client.py
+++ b/sdks/python/memsy/async_client.py
@@ -138,6 +138,8 @@ class AsyncMemsyClient(HttpCoreMixin):
         limit: int = 10,
         threshold: float = 0.0,
         include_source_events: bool = False,
+        role_ids: list[str] | None = None,
+        team_ids: list[str] | None = None,
     ) -> SearchResponse:
         """
         Search memories.
@@ -147,6 +149,8 @@ class AsyncMemsyClient(HttpCoreMixin):
             actor's memories. When omitted (``None``), the search runs org-wide
             across every actor — useful for admin tools and analytics, rarely
             what you want in an end-user-facing agent loop.
+        :param role_ids: Role IDs the actor belongs to — enables role-promoted memories.
+        :param team_ids: Team IDs the actor belongs to — enables team-promoted memories.
         :param limit: Maximum number of results to return (default 10).
         :param threshold: Minimum relevance score (default 0.0 — no filter).
             See https://docs.memsy.io/docs/searching-memory#threshold for
@@ -162,6 +166,10 @@ class AsyncMemsyClient(HttpCoreMixin):
         }
         if actor_id is not None:
             body["actor_id"] = actor_id
+        if role_ids:
+            body["role_ids"] = role_ids
+        if team_ids:
+            body["team_ids"] = team_ids
         data, usage, rate_limit = await self._request("POST", "/search", json=body)
         response = SearchResponse.from_dict(data)
         response.usage = usage

--- a/sdks/python/memsy/client.py
+++ b/sdks/python/memsy/client.py
@@ -140,6 +140,8 @@ class MemsyClient(HttpCoreMixin):
         limit: int = 10,
         threshold: float = 0.0,
         include_source_events: bool = False,
+        role_ids: list[str] | None = None,
+        team_ids: list[str] | None = None,
     ) -> SearchResponse:
         """
         Search memories.
@@ -149,6 +151,8 @@ class MemsyClient(HttpCoreMixin):
             actor's memories. When omitted (``None``), the search runs org-wide
             across every actor — useful for admin tools and analytics, rarely
             what you want in an end-user-facing agent loop.
+        :param role_ids: Role IDs the actor belongs to — enables role-promoted memories.
+        :param team_ids: Team IDs the actor belongs to — enables team-promoted memories.
         :param limit: Maximum number of results to return (default 10).
         :param threshold: Minimum relevance score (default 0.0 — no filter).
             See https://docs.memsy.io/docs/searching-memory#threshold for
@@ -164,6 +168,10 @@ class MemsyClient(HttpCoreMixin):
         }
         if actor_id is not None:
             body["actor_id"] = actor_id
+        if role_ids:
+            body["role_ids"] = role_ids
+        if team_ids:
+            body["team_ids"] = team_ids
         data, usage, rate_limit = self._request("POST", "/search", json=body)
         response = SearchResponse.from_dict(data)
         response.usage = usage

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsy"
-version = "0.3.1"
+version = "0.3.2"
 description = "Official Python SDK for the Memsy memory service"
 requires-python = ">=3.10"
 authors = [

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -210,7 +210,7 @@ wheels = [
 
 [[package]]
 name = "memsy"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
### Description

**PYTHON**
`search()` on both `MemsyClient` and `AsyncMemsyClient` could not pass `role_ids` or `team_ids`, preventing retrieval of role/team-promoted memories for new actors.
**NODE**
`SearchOptions` lacked `roleIds` and `teamIds`, so Node clients couldn’t retrieve promoted memories for new actors. `SourceMetadata` was also not exported, preventing TypeScript consumers from using its type directly.

## What's changed

**Python SDK (memsy/sdks/python/)**
- Added role_ids: list[str] | None and team_ids: list[str] | None parameters to search() on MemsyClient and AsyncMemsyClient
- Both fields are serialized into the /search POST body only when set
- Version bumped: 0.3.1 → 0.3.2

**Node SDK (memsy/sdks/node/)**
- Added roleIds?: string[] and teamIds?: string[] to the SearchOptions interface
- search() now serializes them as role_ids / team_ids in the request body when present (parity with Python)
- Exported SourceMetadata type from index.ts so TypeScript consumers can name it
- Version bumped: 0.1.1 → 0.1.2

## Result
A brand-new actor with zero personal memories now correctly receives role- and team-promoted memories via hierarchical recall when role_ids / team_ids (Python) or roleIds / teamIds (Node) are passed to search(). 
Verified end-to-end against a live Memsy instance — 3/3 promotion queries returned prom_-prefixed memories with the scoping params, and 0 results without them.