### PR TITLE
docs(status): document the 500-event_ids per-call cap (NEW-23)

### DIFF
--- a/docs/content/docs/async-processing.mdx
+++ b/docs/content/docs/async-processing.mdx
@@ -103,6 +103,10 @@ The status response partitions the IDs you sent into three buckets (Python / Nod
 - `pending_ids` / `pendingIds` — still in the queue or mid-processing.
 - `failed_ids` / `failedIds` — something went wrong during extraction. These won't become memories.
 
+<Note>
+**Request limits.** Each `status()` call accepts up to **500 `event_ids`** per request. Requests over the cap return HTTP 422. For larger fan-outs, page through the list in client-side chunks of 500.
+</Note>
+
 ## What causes an event to fail?
 
 - Content rejected by a content filter.


### PR DESCRIPTION
## Summary

Tester reported in the 2026-05-14 report that `POST /v1/status` returns 422 with no documentation of the 500-id cap. Cap is enforced at `memsy-core/memsy/http/schemas.py:164` (`Field(max_length=500)`).

Adds a single `<Note>` callout in async-processing.mdx pointing callers at the cap + the chunk-paginate workaround.

## Test plan

- [ ] Docs site rebuild renders the Note callout