### PR TITLE
docs(quickstart): correct API key prefix to msy_live_

### DIFF
--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -12,7 +12,7 @@ Five minutes to your first memory. This page walks you through **dashboard → i
     Then in **Settings → API Keys**:
 
     1. Click **Create key** and give it a label (`local-dev` works).
-    2. Copy the key — it's shown once and looks like `memsy_live_xxxxxxxxxxxx`.
+    2. Copy the key — it's shown once and looks like `msy_live_xxxxxxxxxxxx`.
     3. While you're there, copy your **API base URL** (e.g. `https://api.memsy.io/v1`).
 
     <Info>
@@ -45,7 +45,7 @@ Five minutes to your first memory. This page walks you through **dashboard → i
   <Step title="Set your credentials">
     ```bash
     export MEMSY_BASE_URL="https://api.memsy.io/v1"
-    export MEMSY_API_KEY="memsy_live_xxxxxxxxxxxx"
+    export MEMSY_API_KEY="msy_live_xxxxxxxxxxxx"
     ```
 
     <Tip>


### PR DESCRIPTION
## Summary

The dashboard mints API keys with the `msy_` prefix (the live service has used `msy_` since the key-format change), but the quickstart still showed the legacy `memsy_live_` prefix. Updates the two illustrative key strings in `quickstart.mdx` so new developers don't think their copied key looks wrong.

## Test plan

- [ ] Skim the rendered quickstart page locally — both occurrences now read `msy_live_xxxxxxxxxxxx`.
- [ ] grep `memsy_live_` across the docs content — should only hit `.next/` build artifacts.