### PR TITLE
docs(search): clarify org-wide search when actor_id is omitted

### DIFF
--- a/docs/content/docs/reference/node/memsy-client.mdx
+++ b/docs/content/docs/reference/node/memsy-client.mdx
@@ -72,7 +72,7 @@ search(query: string, options?: SearchOptions): Promise<SearchResponse>
 
 | Field                | Type      | Default | Description                                                  |
 |----------------------|-----------|---------|--------------------------------------------------------------|
-| `actorId`            | `string`  | —       | Restrict search to a specific actor.                         |
+| `actorId`            | `string`  | —       | Restrict search to a specific actor. Omit to search org-wide across every actor. See [Actor scoping](/docs/searching-memory#actor_id--actorid). |
 | `limit`              | `number`  | `10`    | Max results to return.                                       |
 | `threshold`          | `number`  | `0.0`   | Minimum similarity score. `0.0` = no filter. See [Threshold guidance](/docs/searching-memory#threshold). |
 | `includeSourceEvents`| `boolean` | `false` | Include the originating events alongside each memory.        |

--- a/docs/content/docs/reference/python/memsy-client.mdx
+++ b/docs/content/docs/reference/python/memsy-client.mdx
@@ -74,7 +74,7 @@ search(
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `query` | `str` | — | Natural-language query. |
-| `actor_id` | `str \| None` | `None` | Filter results to a single actor. |
+| `actor_id` | `str \| None` | `None` | Restrict results to a single actor. Omit (`None`) to search org-wide across every actor. See [Actor scoping](/docs/searching-memory#actor_id--actorid). |
 | `limit` | `int` | `10` | Maximum number of results. |
 | `threshold` | `float` | `0.0` | Minimum similarity score. `0.0` = no filter. See [Threshold guidance](/docs/searching-memory#threshold). |
 | `include_source_events` | `bool` | `False` | Include source events in each result. |

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -17,6 +17,11 @@ import { MemoriesResource } from "./resources/memories.js";
 export type MemsyClientOptions = BaseClientOptions;
 
 export interface SearchOptions {
+  /**
+   * Restrict results to a single actor's memories. Omit to search org-wide
+   * across every actor — useful for admin tools and analytics, rarely what
+   * you want in an end-user-facing agent loop.
+   */
   actorId?: string;
   limit?: number;
   /**

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`search(actor_id=...)` docstring clarified**: omitting `actor_id` now explicitly
+  documents as an org-wide search across every actor (matches the server behaviour
+  shipped alongside this release). No SDK API change — the parameter has always been
+  optional; only the documented meaning of "omitted" is sharper.
+
 ## [0.3.0] - 2026-04-29
 
 ### Breaking Changes

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -111,7 +111,7 @@ Retrieve relevant memories using natural language.
 ```python
 results = client.search(
     query="what does the user prefer?",
-    actor_id="user_1",            # optional — scope to a specific user
+    actor_id="user_1",            # optional — restrict to one actor; omit for org-wide search
     limit=10,                     # default: 10
     threshold=0.0,                # minimum relevance score, default: 0.0 (no filter)
     include_source_events=True,   # attach source events to each result

--- a/sdks/python/memsy/async_client.py
+++ b/sdks/python/memsy/async_client.py
@@ -143,7 +143,10 @@ class AsyncMemsyClient(HttpCoreMixin):
         Search memories.
 
         :param query: Natural language query string.
-        :param actor_id: Optional actor/user ID to further scope the search.
+        :param actor_id: Actor/user ID. When set, results are restricted to that
+            actor's memories. When omitted (``None``), the search runs org-wide
+            across every actor — useful for admin tools and analytics, rarely
+            what you want in an end-user-facing agent loop.
         :param limit: Maximum number of results to return (default 10).
         :param threshold: Minimum relevance score (default 0.0 — no filter).
             See https://docs.memsy.io/docs/searching-memory#threshold for

--- a/sdks/python/memsy/client.py
+++ b/sdks/python/memsy/client.py
@@ -145,7 +145,10 @@ class MemsyClient(HttpCoreMixin):
         Search memories.
 
         :param query: Natural language query string.
-        :param actor_id: Optional actor/user ID to further scope the search.
+        :param actor_id: Actor/user ID. When set, results are restricted to that
+            actor's memories. When omitted (``None``), the search runs org-wide
+            across every actor — useful for admin tools and analytics, rarely
+            what you want in an end-user-facing agent loop.
         :param limit: Maximum number of results to return (default 10).
         :param threshold: Minimum relevance score (default 0.0 — no filter).
             See https://docs.memsy.io/docs/searching-memory#threshold for


### PR DESCRIPTION
## Summary

After the memsy-core search PRs landed (server-side \`include_all_actors\` flag — omitting \`actor_id\` now runs an org-wide retrieval across every actor), the narrative \`searching-memory.mdx\` page was updated to match. This PR closes the remaining gaps in the SDK-facing surfaces that still framed \`actor_id\` only as a filter:

- **Python SDK** — \`search()\` docstring on both \`MemsyClient\` and \`AsyncMemsyClient\`; inline kwarg comment in README; \`CHANGELOG.md\` Unreleased entry.
- **Node SDK** — JSDoc on \`SearchOptions.actorId\`.
- **Docs site** — \`actor_id\` / \`actorId\` reference-table rows (Python + Node) now mention the omit semantic and link back to the narrative section.

**No SDK API change.** \`actor_id\` has always been \`str | None = None\`; only the documented meaning of "omitted" is sharper.

## Test plan

- [ ] Build the docs site locally and check the Python + Node reference pages render correctly with the deep link to \`#actor_id--actorid\`.
- [ ] \`uv build\` the Python SDK — docstrings render in help() / Sphinx without errors.
- [ ] \`npm run build\` the Node SDK — \`dist/index.d.ts\` picks up the new JSDoc on \`SearchOptions.actorId\`.
- [ ] grep for \"further scope the search\" — should return zero hits.