### PR TITLE
docs(quickstart): drop msy_live_ prefix in placeholder keys

### DIFF
--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -12,7 +12,7 @@ Five minutes to your first memory. This page walks you through **dashboard → i
     Then in **Settings → API Keys**:
 
     1. Click **Create key** and give it a label (`local-dev` works).
-    2. Copy the key — it's shown once and looks like `msy_live_xxxxxxxxxxxx`.
+    2. Copy the key — it's shown once and looks like `msy_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`.
     3. While you're there, copy your **API base URL** (e.g. `https://api.memsy.io/v1`).
 
     <Info>
@@ -45,7 +45,7 @@ Five minutes to your first memory. This page walks you through **dashboard → i
   <Step title="Set your credentials">
     ```bash
     export MEMSY_BASE_URL="https://api.memsy.io/v1"
-    export MEMSY_API_KEY="msy_live_xxxxxxxxxxxx"
+    export MEMSY_API_KEY="msy_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     ```
 
     <Tip>


### PR DESCRIPTION
## Summary

The dashboard mints API keys without an environment prefix — just `msy_` followed by 32 hex chars. The `signup.mdx` page already uses this shape (`msy_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`), but `quickstart.mdx` was still showing the legacy `msy_live_xxxxxxxxxxxx` form. This means a new user lands on quickstart, copies their real key from the dashboard, and sees that it looks shorter and lacks the `live_` segment shown in the docs — exactly the kind of "is my key wrong?" friction we want to remove from onboarding.

This PR aligns the two illustrative placeholders in `quickstart.mdx` with `signup.mdx`. No other docs reference `msy_live_` (`grep`'d the whole tree).

## Diff

- `quickstart.mdx:15` — `\`msy_live_xxxxxxxxxxxx\`` → `\`msy_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\``
- `quickstart.mdx:48` — `MEMSY_API_KEY="msy_live_xxxxxxxxxxxx"` → `MEMSY_API_KEY="msy_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"`

## Test plan

- [ ] Open the rendered quickstart page in preview — both example keys read `msy_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`.
- [ ] `grep -r msy_live_ docs/` returns zero hits.
- [ ] Side-by-side quickstart vs signup — same example key shape on both.