### PR TITLE
fix(mcp): NodeNext resolution so DTS build finds MCP SDK types

### DIFF
--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## Summary

- tsup DTS step failed on Gaurav's machine: `Cannot find module '@modelcontextprotocol/sdk/server/mcp.js' or its corresponding type declarations`
- Root cause: under `moduleResolution: "Bundler"`, tsup's DTS pass (rollup-plugin-dts) can resolve the SDK's runtime ESM via `exports`, but doesn't reliably traverse the SDK's `typesVersions` map to find the matching `.d.ts` siblings
- Fix: switch `mcp/tsconfig.json` to `module: "NodeNext"` + `moduleResolution: "NodeNext"`. NodeNext follows the `exports` map strictly and strips the `.js` extension to locate adjacent `.d.ts` files
- All existing imports already use `.js` extensions, so no source changes needed

## Verification

- [x] `npm run build` (mcp workspace) — ESM 55.24 KB + `dist/server.d.ts` both emit cleanly
- [x] `npm test` — 55/55 passing
- [ ] Confirm Gaurav can build locally from this branch