### PR TITLE
feat(mcp): default memsy_list_memories to the active actor

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memsy-io/mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Memsy MCP server - Drop-in memory infrastructure that learns at the role, team, and org level — so your AI app gets smarter as more agents and humans use it.",
   "type": "module",
   "bin": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memsy-io/mcp",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "description": "Memsy MCP server - Drop-in memory infrastructure that learns at the role, team, and org level — so your AI app gets smarter as more agents and humans use it.",
   "type": "module",
   "bin": {

--- a/mcp/src/tools/list_memories.ts
+++ b/mcp/src/tools/list_memories.ts
@@ -4,12 +4,46 @@ import { z } from "zod";
 import type { ProfileManager } from "../profiles.js";
 import { formatError, jsonResult } from "./_shared.js";
 
+/**
+ * Resolve which actor a list call should be scoped to.
+ *
+ * Precedence:
+ *   1. An explicit, non-empty `actorId` always wins — filter to that actor.
+ *   2. `allActors: true` opts into the org-wide view — no actor filter.
+ *   3. Otherwise default to the active profile's actor, so a bare
+ *      `memsy_list_memories` returns only the caller's own memories rather
+ *      than every actor in the org.
+ *
+ * Returns the actor_id to filter by, or `undefined` for "every actor".
+ */
+export function resolveListActorScope(opts: {
+  actorId?: string;
+  allActors?: boolean;
+  activeActorId?: string;
+}): string | undefined {
+  if (opts.actorId && opts.actorId.trim()) return opts.actorId;
+  if (opts.allActors) return undefined;
+  return opts.activeActorId;
+}
+
 export function registerListMemories(server: McpServer, profiles: ProfileManager): void {
   server.tool(
     "memsy_list_memories",
-    "List extracted memories from the Memsy console (admin/management view). Distinct from memsy_search: this is a flat paginated listing, not semantic ranking. Use for browsing, dashboards, or audits.",
+    "List extracted memories from the Memsy console (admin/management view). Distinct from memsy_search: this is a flat paginated listing, not semantic ranking. Defaults to the ACTIVE actor only — pass all_actors:true for an org-wide view across every actor, or actor_id to filter to a specific actor. Use for browsing, dashboards, or audits.",
     {
-      actor_id: z.string().optional().describe("Filter by actor."),
+      actor_id: z
+        .string()
+        .optional()
+        .describe(
+          "Filter to a specific actor. Omit to use the active actor (the default); set all_actors:true for every actor.",
+        ),
+      all_actors: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "List across every actor (org-wide) instead of just the active one. Ignored when actor_id is set.",
+        ),
       kind: z.string().optional().describe('Memory kind (e.g. "fact", "decision", "preference").'),
       type: z.string().optional().describe("Memory type taxonomy from memsy-core."),
       status: z.string().optional().describe('e.g. "active" or "archived".'),
@@ -25,8 +59,13 @@ export function registerListMemories(server: McpServer, profiles: ProfileManager
     async (args) => {
       try {
         const ctx = profiles.current();
-        const res = await ctx.client.memories.list({
+        const actorId = resolveListActorScope({
           actorId: args.actor_id,
+          allActors: args.all_actors,
+          activeActorId: ctx.identity.actorId,
+        });
+        const res = await ctx.client.memories.list({
+          actorId,
           kind: args.kind,
           type: args.type,
           status: args.status,
@@ -37,6 +76,9 @@ export function registerListMemories(server: McpServer, profiles: ProfileManager
         });
         return jsonResult({
           profile: ctx.profileName,
+          // Tell the caller what scope was applied so a UI can label it
+          // ("memories for <actor>" vs "all actors") without guessing.
+          actor_scope: actorId ?? "all-actors",
           total: res.total,
           limit: res.limit,
           offset: res.offset,

--- a/mcp/test/list_memories.test.ts
+++ b/mcp/test/list_memories.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveListActorScope } from "../src/tools/list_memories.js";
+
+describe("resolveListActorScope", () => {
+  it("defaults to the active actor when nothing else is specified", () => {
+    expect(resolveListActorScope({ activeActorId: "claude-code" })).toBe("claude-code");
+  });
+
+  it("returns undefined (org-wide) when all_actors is set", () => {
+    expect(
+      resolveListActorScope({ allActors: true, activeActorId: "claude-code" }),
+    ).toBeUndefined();
+  });
+
+  it("uses an explicit actor_id over the active actor", () => {
+    expect(
+      resolveListActorScope({ actorId: "alex-dev", activeActorId: "claude-code" }),
+    ).toBe("alex-dev");
+  });
+
+  it("lets an explicit actor_id win even when all_actors is also true", () => {
+    expect(
+      resolveListActorScope({ actorId: "alex-dev", allActors: true, activeActorId: "claude-code" }),
+    ).toBe("alex-dev");
+  });
+
+  it("ignores a blank or whitespace-only actor_id and falls back to the default", () => {
+    expect(resolveListActorScope({ actorId: "   ", activeActorId: "claude-code" })).toBe(
+      "claude-code",
+    );
+    expect(resolveListActorScope({ actorId: "", activeActorId: "claude-code" })).toBe(
+      "claude-code",
+    );
+  });
+
+  it("returns undefined when there is no active actor and no override", () => {
+    expect(resolveListActorScope({})).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Makes `memsy_list_memories` default to the **active actor** instead of listing every actor in the org.

## Problem
`memsy_list_memories` accepted an optional `actor_id` and, when it was omitted, returned memories across **all** actors. Callers (and plugin "list memories" flows) generally expect to see *their own* memories by default, so the org-wide default was surprising.

## Change
Scope is now resolved by precedence:

| Input | Result |
|---|---|
| `actor_id` set | that specific actor (unchanged) |
| `all_actors: true` | every actor (org-wide) |
| neither (default) | the **active** profile's actor |

- New optional `all_actors` boolean for the explicit org-wide view.
- Resolution lives in a pure, exported helper `resolveListActorScope()` so it's unit-testable.
- The response now includes `actor_scope` (the actor id, or `"all-actors"`) so a UI can label what it's showing.

## Tests
- Adds `test/list_memories.test.ts` (6 cases: default, `all_actors`, explicit `actor_id`, precedence, blank-actor fallback, no-active-actor).
- Full suite: **61 passed**. `tsup` build succeeds.

## Compatibility
Behavior change: a bare `memsy_list_memories` call now returns the active actor's memories rather than all actors. Pass `all_actors: true` (or `actor_id`) for the previous/other scopes.
