### PR TITLE
fix(mcp): derive VERSION from package.json

### DIFF
--- a/docs/content/docs/mcp.mdx
+++ b/docs/content/docs/mcp.mdx
@@ -482,7 +482,7 @@ Wrong `base_url`. Production hot-path is `https://api.memsy.io/v1` — the `/v1`
 The query may not semantically match. Try:
 
 - Broader terms / single keyword.
-- `memsy_list_memories` (no args) to see what's actually stored.
+- `memsy_list_memories` with `all_actors: true` to see everything stored (with no args it lists only your active actor).
 - `threshold: 0` (the default — anything stricter hides weak matches).
 
 Search is org-wide by default, so prior-channel memories are findable without setting `actor_id`.
@@ -504,6 +504,20 @@ Common causes:
 ### Profile switch doesn't persist across sessions
 
 `memsy_use_org` swaps the active profile in the current MCP process only. Each host spawns a fresh process per chat. To change the default at startup, set `MEMSY_PROFILE` in the host's MCP `env`, or update `active_profile` in the config file.
+
+### Server is running an old version (a new feature or fix isn't showing up)
+
+The server runs via `npx -y @memsy-io/mcp`, which uses the latest published version — usually you just restart your host and npx pulls the new release. If a recent change still isn't taking effect, in order of likelihood:
+
+1. **A global install is shadowing `npx`.** If `@memsy-io/mcp` is installed globally, `npx -y @memsy-io/mcp` runs *that* copy instead of fetching the latest — the most common cause.
+   ```bash
+   npm ls -g @memsy-io/mcp        # if it's listed, it's shadowing npx
+   npm uninstall -g @memsy-io/mcp # let npx pull the latest, then restart your host
+   ```
+2. **A stale `npx` cache.** Quit your host, run `rm -rf "$(npm config get cache)/_npx"`, then restart.
+3. **A still-running process.** The server is long-lived per host session — fully restart the host (or `pkill -f "@memsy-io/mcp"`) so a fresh one spawns.
+
+Verify with `npm ls -g @memsy-io/mcp` (no global install = good) or behaviorally, rather than the startup banner.
 
 ## Security notes
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -412,7 +412,7 @@ Wrong `base_url`. Production hot-path is `https://api.memsy.io/v1` — the `/v1`
 
 The query may not semantically match. Try:
 - Broader terms / single keyword
-- `memsy_list_memories` (no args) → see what's actually stored
+- `memsy_list_memories` with `all_actors: true` → see everything stored (with no args it lists only your active actor)
 - `threshold: 0` (default) — anything stricter hides weak matches
 
 If you previously stored memories with a specific `actor_id` (via dashboard or SDK), they're still findable since search is org-wide by default. Don't pass `actor_id` unless you want to scope down.
@@ -433,6 +433,20 @@ Common causes:
 ### Profile-switching doesn't seem to persist
 
 It only persists for the lifetime of the MCP process. Each host spawns a fresh process per chat/session. To make a different profile the default at startup, set `MEMSY_PROFILE` in the host's MCP `env`, or update `active_profile` in the config file.
+
+### Server is running an old version (a new feature or fix isn't showing up)
+
+The server runs via `npx -y @memsy-io/mcp`, which uses the latest published version — usually you just restart your host and npx pulls the new release. If a recent change still isn't taking effect, in order of likelihood:
+
+1. **A global install is shadowing `npx`.** If `@memsy-io/mcp` is installed globally, `npx -y @memsy-io/mcp` runs *that* copy instead of fetching the latest — the most common cause.
+   ```bash
+   npm ls -g @memsy-io/mcp        # if it's listed, it's shadowing npx
+   npm uninstall -g @memsy-io/mcp # let npx pull the latest, then restart your host
+   ```
+2. **A stale `npx` cache.** Quit your host, run `rm -rf "$(npm config get cache)/_npx"`, then restart.
+3. **A still-running process.** The server is long-lived per host session — fully restart the host (or `pkill -f "@memsy-io/mcp"`) so a fresh one spawns.
+
+Verify with `npm ls -g @memsy-io/mcp` (no global install = good) or behaviorally, rather than the startup banner.
 
 ---
 

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
@@ -7,7 +9,13 @@ import { registerAllPrompts } from "./prompts/index.js";
 import { registerAllResources } from "./resources/index.js";
 import { registerAllTools } from "./tools/index.js";
 
-const VERSION = "0.1.0";
+// Read the version from the package manifest at runtime so the banner,
+// --version, and the MCP handshake always match the published package — no
+// hand-maintained constant to drift (it previously lagged at "0.1.0").
+// Resolved relative to this module: dist/server.js -> ../package.json.
+const VERSION: string = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+).version;
 const SERVER_NAME = "@memsy-io/mcp";
 
 const HELP_TEXT = `memsy-mcp ${VERSION} — Memsy MCP server (drop-in memory that learns at role / team / org level)


### PR DESCRIPTION
Fixes a misleading version report in the MCP server.

## Problem
`mcp/src/server.ts` hardcoded `const VERSION = "0.1.0"`, separate from `package.json`. When `package.json` was bumped to `0.1.1`, this constant wasn't, so the **startup banner**, **`--version`**, and the **MCP handshake** all kept reporting `0.1.0` even while running the `0.1.1` code — which made it hard to tell which build was actually running.

## Change
Read the version from the adjacent `package.json` at runtime (resolved relative to the module: `dist/server.js` → `../package.json`), so the reported version always matches the published package and can't drift again.

```ts
const VERSION: string = JSON.parse(
  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
).version;
```

Chosen over a static `import … from "../package.json"` to avoid `rootDir`/`.d.ts` build friction under `NodeNext`; not exercised by the unit tests (none import `server.ts`).

## Verification
- `node dist/server.js --version` now prints `0.1.1` (was `0.1.0`).
- `tsup` build succeeds; **61/61 tests pass**.

## Note
**No version bump** in this PR (intentional). `package.json` stays `0.1.1`; the live banner/handshake will correct on the next publish.
