### PR TITLE
docs: document all six data connectors

### DIFF
--- a/docs/content/docs/connectors.mdx
+++ b/docs/content/docs/connectors.mdx
@@ -1,0 +1,151 @@
+---
+title: Connectors
+description: Sync Slack, Google Drive, Notion, GitHub, OneDrive, and S3 into Memsy automatically — no SDK code required.
+---
+
+Connectors pull content from external sources into Memsy without your app calling `ingest()` directly. An org admin connects a workspace (or a member connects their own account) once in the [Memsy console](https://app.memsy.io); Memsy then syncs new content on an ongoing basis and it shows up as searchable memory alongside everything else.
+
+<Info>
+  Connectors are configured and managed from the console UI. This page documents what each connector syncs, how it's scoped, and what an admin needs to set up before it can be connected — useful if you're debugging a sync or deciding which connector fits your data.
+</Info>
+
+## How connectors work
+
+Every connector implements the same contract: authenticate, let the user pick what to sync (a channel, a folder, a bucket, a repo branch...), then fetch content on a recurring basis. Fetched content is normalized into events and ingested through the same pipeline as `append()` calls — connector-sourced memories are indistinguishable from SDK-sourced ones once they land.
+
+Syncs are event-driven, not polled: a webhook (Slack, GitHub), a manual "Sync now" click, or completing setup all trigger an immediate sync.
+
+### Org-scoped vs. user-scoped
+
+| Scoping | Meaning | Connectors |
+|---|---|---|
+| **Org-scoped** | One shared connection per org. Any member can see it; only an org admin (or a service API key) can connect, reconfigure, or disconnect it. Resulting memories are org-visible. | Slack, Notion, GitHub, S3 |
+| **User-scoped** | Each member connects their own account. Only the owner (or a service key) can manage it or list its resources; resulting memories are private to that member. | Google Drive, OneDrive |
+
+## Available connectors
+
+| Connector | Syncs | Scoping | Live updates |
+|---|---|---|---|
+| [Slack](#slack) | Public channel messages | Org | Webhook (Events API) |
+| [Google Drive](#google-drive) | Files picked via Google Picker | User | Manual / recurring sync |
+| [Notion](#notion) | Pages in a shared workspace | Org | Manual / recurring sync |
+| [GitHub](#github) | Markdown/doc files in selected repo branches | Org | Webhook (push events) |
+| [OneDrive](#onedrive) | Files/folders picked from a Microsoft Graph folder browser | User | Manual / recurring sync |
+| [S3](#s3) | Objects in one bucket | Org | Manual / recurring sync |
+
+---
+
+## Slack
+
+Streams messages from public channels the bot has joined. Phase 1 covers public channels only — private channels and DMs aren't synced.
+
+- **OAuth scopes:** `channels:read`, `channels:history`, `channels:join`, `users:read`, `users:read.email`, `team:read`
+- **Live updates:** the Slack Events API webhook triggers a resync on new messages; bot tokens (`xoxb-`) don't expire, so there's no refresh step.
+- **Setup:** create a Slack app with the scopes above, then set:
+
+```bash
+SLACK_CLIENT_ID=...
+SLACK_CLIENT_SECRET=...
+SLACK_SIGNING_SECRET=...
+```
+
+An admin connects the workspace, picks channels from the picker (the bot auto-joins each one), and sync starts immediately.
+
+## Google Drive
+
+Syncs individual files a user grants through the browser-based [Google Picker](https://developers.google.com/picker) — not a folder tree. Memsy requests the narrow `drive.file` scope, so it can only ever see files explicitly picked, never a user's whole Drive. Google-native Docs/Sheets/Slides are exported (to docx/xlsx/pptx) before text extraction; everything else is read as-is.
+
+- **Scoping:** user-scoped — each member connects their own Drive, and only they can pick files or see the connection's resources.
+- **Live updates:** no webhook (Drive push notifications are a future phase) — re-sync on demand or on schedule.
+- **Setup:**
+
+```bash
+GOOGLE_CLIENT_ID=...
+GOOGLE_CLIENT_SECRET=...
+GOOGLE_PICKER_API_KEY=...
+GOOGLE_APP_ID=...
+```
+
+Because `drive.file` can't enumerate a user's Drive server-side, the console mints a short-lived Picker token (`GET /connectors/{id}/picker-token`) and the file selection happens entirely in the browser.
+
+## Notion
+
+Syncs pages across a whole shared workspace as one synthetic resource — there's no per-page picker. Each sync sweep re-runs Notion's Search API and pulls pages edited since the last run, pulling full content via the Markdown export endpoint.
+
+- **OAuth scopes:** `read_content`
+- **Scoping:** org-scoped — a Notion connection is a workspace-level grant made by a workspace admin; resulting memories are org-visible.
+- **Live updates:** no inbound webhook — pull-based sweeps only.
+- **Setup:**
+
+```bash
+NOTION_CLIENT_ID=...
+NOTION_CLIENT_SECRET=...
+```
+
+Connecting activates automatically (no resource-picker step) — Notion has a single implicit resource, the shared workspace.
+
+## GitHub
+
+A *documentation* connector: for each selected repository branch, it ingests supported doc files (Markdown and similar text formats), not general source code. The default branch gets a full backfill on first sync; other branches are register-only until their next push.
+
+- **OAuth scopes:** `repo`, `user:email`, `admin:repo_hook`
+- **Scoping:** org-scoped.
+- **Live updates:** installs a per-repo webhook (push/create/delete), verified against `GITHUB_WEBHOOK_SECRET` — removed automatically when the connector is disconnected.
+- **Setup:**
+
+```bash
+GITHUB_CLIENT_ID=...
+GITHUB_CLIENT_SECRET=...
+GITHUB_WEBHOOK_SECRET=...
+GITHUB_WEBHOOK_URL=...
+# optional — restrict incremental (post-backfill) ingestion to specific
+# GitHub logins; empty (default) trusts GitHub's own repo permissions
+GITHUB_INGEST_AUTHOR_ALLOWLIST=alice,bob
+```
+
+Repos load lazily in the picker; expanding one calls `GET /connectors/{id}/branches?repo=...` to list its branches without fetching every repo's branches up front.
+
+## OneDrive
+
+Like Google Drive, syncs individual files — but because the delegated `Files.Read` scope allows server-side enumeration, resources are picked from a real folder browser (drill down via `parent_id`) rather than a client-side Picker. Selecting a folder syncs its whole subtree.
+
+- **OAuth scopes:** `openid`, `profile`, `offline_access`, `User.Read`, `Files.Read`
+- **Scoping:** user-scoped — each member connects their own OneDrive; memories are private to that member, attributed to the file's last editor when Graph reports one.
+- **Live updates:** no webhook yet (Graph change notifications are a future phase) — manual/recurring sync.
+- **Setup:**
+
+```bash
+ONEDRIVE_CLIENT_ID=...
+ONEDRIVE_CLIENT_SECRET=...
+# optional — defaults to the Microsoft "common" multi-tenant authority
+ONEDRIVE_AUTHORITY=...
+```
+
+## S3
+
+Syncs every object in one bucket using static IAM credentials — no OAuth, no browser redirect. One S3 connection per org.
+
+- **Auth:** direct IAM access key + secret (submitted once via the console; no refresh, no expiry)
+- **Scoping:** org-scoped.
+- **Live updates:** no webhook yet (SNS/SQS notifications are a future phase) — manual/recurring sync, using a continuation-token cursor plus a last-modified high-water mark to skip unchanged objects.
+- **Setup:** no environment variables — an admin submits `access_key_id`, `secret_access_key`, `region`, and `bucket` directly. Memsy validates the credentials and resolves the underlying IAM identity before saving them.
+
+---
+
+## Managing connections
+
+All connector management goes through the control-plane API (the console UI is a thin client over it):
+
+| Action | Endpoint |
+|---|---|
+| List available providers | `GET /connectors/providers` |
+| Start an OAuth connection | `POST /connectors/{provider}/connect` |
+| Configure S3 (no OAuth) | `POST /connectors/s3/configure` |
+| List your org's connections | `GET /connectors` |
+| Check if a provider is connected | `GET /connectors/{provider}/status` |
+| Browse a connection's resources | `GET /connectors/{connector_id}/resources` |
+| Select resources to sync | `PUT /connectors/{connector_id}/resources` |
+| Trigger a sync immediately | `POST /connectors/{connector_id}/sync` |
+| Disconnect | `DELETE /connectors/{connector_id}` |
+
+Disconnecting revokes the stored token/credentials and — for providers that installed one (GitHub) — removes the webhook, so nothing is left behind on the external side.

--- a/docs/content/docs/connectors.mdx
+++ b/docs/content/docs/connectors.mdx
@@ -1,151 +1,77 @@
 ---
 title: Connectors
-description: Sync Slack, Google Drive, Notion, GitHub, OneDrive, and S3 into Memsy automatically — no SDK code required.
+description: Connect Slack, Google Drive, Notion, GitHub, OneDrive, and S3 to Memsy from the console — no code required.
 ---
 
-Connectors pull content from external sources into Memsy without your app calling `ingest()` directly. An org admin connects a workspace (or a member connects their own account) once in the [Memsy console](https://app.memsy.io); Memsy then syncs new content on an ongoing basis and it shows up as searchable memory alongside everything else.
-
-<Info>
-  Connectors are configured and managed from the console UI. This page documents what each connector syncs, how it's scoped, and what an admin needs to set up before it can be connected — useful if you're debugging a sync or deciding which connector fits your data.
-</Info>
-
-## How connectors work
-
-Every connector implements the same contract: authenticate, let the user pick what to sync (a channel, a folder, a bucket, a repo branch...), then fetch content on a recurring basis. Fetched content is normalized into events and ingested through the same pipeline as `append()` calls — connector-sourced memories are indistinguishable from SDK-sourced ones once they land.
-
-Syncs are event-driven, not polled: a webhook (Slack, GitHub), a manual "Sync now" click, or completing setup all trigger an immediate sync.
-
-### Org-scoped vs. user-scoped
-
-| Scoping | Meaning | Connectors |
-|---|---|---|
-| **Org-scoped** | One shared connection per org. Any member can see it; only an org admin (or a service API key) can connect, reconfigure, or disconnect it. Resulting memories are org-visible. | Slack, Notion, GitHub, S3 |
-| **User-scoped** | Each member connects their own account. Only the owner (or a service key) can manage it or list its resources; resulting memories are private to that member. | Google Drive, OneDrive |
+Connectors bring content from the tools you already use into Memsy automatically. Connect one from the [Memsy console](https://app.memsy.io) → **Connectors**, and its content becomes searchable memory alongside everything else — no SDK, no code.
 
 ## Available connectors
 
-| Connector | Syncs | Scoping | Live updates |
-|---|---|---|---|
-| [Slack](#slack) | Public channel messages | Org | Webhook (Events API) |
-| [Google Drive](#google-drive) | Files picked via Google Picker | User | Manual / recurring sync |
-| [Notion](#notion) | Pages in a shared workspace | Org | Manual / recurring sync |
-| [GitHub](#github) | Markdown/doc files in selected repo branches | Org | Webhook (push events) |
-| [OneDrive](#onedrive) | Files/folders picked from a Microsoft Graph folder browser | User | Manual / recurring sync |
-| [S3](#s3) | Objects in one bucket | Org | Manual / recurring sync |
+| Connector | Brings in | Who can connect it |
+|---|---|---|
+| [Slack](#slack) | Messages from public channels | Org admin |
+| [Google Drive](#google-drive) | Files you pick | Any member (your own Drive) |
+| [Notion](#notion) | Pages across your workspace | Org admin |
+| [GitHub](#github) | Docs/README files from selected repos | Org admin |
+| [OneDrive](#onedrive) | Files/folders you pick | Any member (your own OneDrive) |
+| [S3](#s3) | Objects in a bucket | Org admin |
 
----
+Slack, Notion, GitHub, and S3 are **shared** connections — one per organization, visible to every member once an admin sets it up. Google Drive and OneDrive are **personal** — each person connects their own account, and only they can see and manage that connection.
 
 ## Slack
 
-Streams messages from public channels the bot has joined. Phase 1 covers public channels only — private channels and DMs aren't synced.
+1. Go to **Connectors → Slack → Connect**.
+2. Sign in to your Slack workspace and approve the requested permissions.
+3. Pick the channels you want Memsy to read. Memsy joins each one automatically.
+4. That's it — new messages in those channels start showing up as memory.
 
-- **OAuth scopes:** `channels:read`, `channels:history`, `channels:join`, `users:read`, `users:read.email`, `team:read`
-- **Live updates:** the Slack Events API webhook triggers a resync on new messages; bot tokens (`xoxb-`) don't expire, so there's no refresh step.
-- **Setup:** create a Slack app with the scopes above, then set:
-
-```bash
-SLACK_CLIENT_ID=...
-SLACK_CLIENT_SECRET=...
-SLACK_SIGNING_SECRET=...
-```
-
-An admin connects the workspace, picks channels from the picker (the bot auto-joins each one), and sync starts immediately.
+Only public channels are supported today; private channels and DMs aren't synced.
 
 ## Google Drive
 
-Syncs individual files a user grants through the browser-based [Google Picker](https://developers.google.com/picker) — not a folder tree. Memsy requests the narrow `drive.file` scope, so it can only ever see files explicitly picked, never a user's whole Drive. Google-native Docs/Sheets/Slides are exported (to docx/xlsx/pptx) before text extraction; everything else is read as-is.
+1. Go to **Connectors → Google Drive → Connect**.
+2. Sign in with Google.
+3. A file picker opens — select the files you want Memsy to read. Memsy only ever sees the files you pick, never your whole Drive.
+4. Come back anytime to pick more files, or disconnect from the same page.
 
-- **Scoping:** user-scoped — each member connects their own Drive, and only they can pick files or see the connection's resources.
-- **Live updates:** no webhook (Drive push notifications are a future phase) — re-sync on demand or on schedule.
-- **Setup:**
-
-```bash
-GOOGLE_CLIENT_ID=...
-GOOGLE_CLIENT_SECRET=...
-GOOGLE_PICKER_API_KEY=...
-GOOGLE_APP_ID=...
-```
-
-Because `drive.file` can't enumerate a user's Drive server-side, the console mints a short-lived Picker token (`GET /connectors/{id}/picker-token`) and the file selection happens entirely in the browser.
+This connection is personal to you — your teammates need to connect their own Drive to bring in their own files.
 
 ## Notion
 
-Syncs pages across a whole shared workspace as one synthetic resource — there's no per-page picker. Each sync sweep re-runs Notion's Search API and pulls pages edited since the last run, pulling full content via the Markdown export endpoint.
+1. Go to **Connectors → Notion → Connect**.
+2. Sign in to Notion and choose which pages/workspace to share with Memsy on Notion's own permission screen.
+3. Connecting activates immediately — there's no separate page picker in Memsy; Notion decides what's shared at the point you grant access.
 
-- **OAuth scopes:** `read_content`
-- **Scoping:** org-scoped — a Notion connection is a workspace-level grant made by a workspace admin; resulting memories are org-visible.
-- **Live updates:** no inbound webhook — pull-based sweeps only.
-- **Setup:**
-
-```bash
-NOTION_CLIENT_ID=...
-NOTION_CLIENT_SECRET=...
-```
-
-Connecting activates automatically (no resource-picker step) — Notion has a single implicit resource, the shared workspace.
+Everything shared this way becomes visible org-wide.
 
 ## GitHub
 
-A *documentation* connector: for each selected repository branch, it ingests supported doc files (Markdown and similar text formats), not general source code. The default branch gets a full backfill on first sync; other branches are register-only until their next push.
-
-- **OAuth scopes:** `repo`, `user:email`, `admin:repo_hook`
-- **Scoping:** org-scoped.
-- **Live updates:** installs a per-repo webhook (push/create/delete), verified against `GITHUB_WEBHOOK_SECRET` — removed automatically when the connector is disconnected.
-- **Setup:**
-
-```bash
-GITHUB_CLIENT_ID=...
-GITHUB_CLIENT_SECRET=...
-GITHUB_WEBHOOK_SECRET=...
-GITHUB_WEBHOOK_URL=...
-# optional — restrict incremental (post-backfill) ingestion to specific
-# GitHub logins; empty (default) trusts GitHub's own repo permissions
-GITHUB_INGEST_AUTHOR_ALLOWLIST=alice,bob
-```
-
-Repos load lazily in the picker; expanding one calls `GET /connectors/{id}/branches?repo=...` to list its branches without fetching every repo's branches up front.
+1. Go to **Connectors → GitHub → Connect**.
+2. Sign in to GitHub and authorize access.
+3. Pick the repositories (and branches) you want synced. Expand a repo to see its branches.
+4. Memsy reads documentation files (READMEs, Markdown docs, etc.) — not general source code — and keeps them up to date automatically as they're pushed.
 
 ## OneDrive
 
-Like Google Drive, syncs individual files — but because the delegated `Files.Read` scope allows server-side enumeration, resources are picked from a real folder browser (drill down via `parent_id`) rather than a client-side Picker. Selecting a folder syncs its whole subtree.
-
-- **OAuth scopes:** `openid`, `profile`, `offline_access`, `User.Read`, `Files.Read`
-- **Scoping:** user-scoped — each member connects their own OneDrive; memories are private to that member, attributed to the file's last editor when Graph reports one.
-- **Live updates:** no webhook yet (Graph change notifications are a future phase) — manual/recurring sync.
-- **Setup:**
-
-```bash
-ONEDRIVE_CLIENT_ID=...
-ONEDRIVE_CLIENT_SECRET=...
-# optional — defaults to the Microsoft "common" multi-tenant authority
-ONEDRIVE_AUTHORITY=...
-```
+1. Go to **Connectors → OneDrive → Connect**.
+2. Sign in with your Microsoft account.
+3. Browse your OneDrive and select the files or folders to sync — picking a folder brings in everything inside it.
+4. This connection is personal — teammates connect their own OneDrive separately.
 
 ## S3
 
-Syncs every object in one bucket using static IAM credentials — no OAuth, no browser redirect. One S3 connection per org.
+1. Go to **Connectors → S3 → Connect**.
+2. Enter your AWS access key, secret key, region, and bucket name.
+3. Memsy validates the credentials and starts syncing every object in that bucket.
 
-- **Auth:** direct IAM access key + secret (submitted once via the console; no refresh, no expiry)
-- **Scoping:** org-scoped.
-- **Live updates:** no webhook yet (SNS/SQS notifications are a future phase) — manual/recurring sync, using a continuation-token cursor plus a last-modified high-water mark to skip unchanged objects.
-- **Setup:** no environment variables — an admin submits `access_key_id`, `secret_access_key`, `region`, and `bucket` directly. Memsy validates the credentials and resolves the underlying IAM identity before saving them.
+Only one S3 bucket connection is supported per organization at a time.
 
----
+## Managing a connection
 
-## Managing connections
+From any connector's page in the console you can:
 
-All connector management goes through the control-plane API (the console UI is a thin client over it):
+- **Sync now** — trigger an immediate sync instead of waiting for the next automatic one
+- **Change selection** — pick different channels/folders/repos (Slack, Drive, GitHub, OneDrive)
+- **Disconnect** — revoke access; Memsy stops syncing and cleans up anything it installed on the provider's side (e.g. GitHub webhooks)
 
-| Action | Endpoint |
-|---|---|
-| List available providers | `GET /connectors/providers` |
-| Start an OAuth connection | `POST /connectors/{provider}/connect` |
-| Configure S3 (no OAuth) | `POST /connectors/s3/configure` |
-| List your org's connections | `GET /connectors` |
-| Check if a provider is connected | `GET /connectors/{provider}/status` |
-| Browse a connection's resources | `GET /connectors/{connector_id}/resources` |
-| Select resources to sync | `PUT /connectors/{connector_id}/resources` |
-| Trigger a sync immediately | `POST /connectors/{connector_id}/sync` |
-| Disconnect | `DELETE /connectors/{connector_id}` |
-
-Disconnecting revokes the stored token/credentials and — for providers that installed one (GitHub) — removes the webhook, so nothing is left behind on the external side.
+Shared connectors (Slack, Notion, GitHub, S3) can only be connected, reconfigured, or disconnected by an org admin — other members can see that it's connected but can't change it. Personal connectors (Google Drive, OneDrive) can only be managed by the person who connected them.

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -22,6 +22,7 @@
     "---Integrations---",
     "langchain",
     "mcp",
+    "connectors",
     "---Plugins---",
     "claude-code",
     "codex",

--- a/docs/lib/page-icons.tsx
+++ b/docs/lib/page-icons.tsx
@@ -133,6 +133,7 @@ const PAGE_ICONS: Record<string, IconComponent> = {
   // Integrations
   langchain: LangChainIcon,
   mcp: McpIcon,
+  connectors: Plug,
 
   // Plugins
   'claude-code': AnthropicIcon,


### PR DESCRIPTION
## Summary
- Adds a Connectors page covering Slack, Google Drive, Notion, GitHub, OneDrive, and S3 — what each syncs, org- vs user-scoping, live-update behavior, and the env vars an admin needs for OAuth/webhook setup.
- Documents the control-plane connector management API (connect, configure, list, sync, disconnect).
- Wires the new page into the docs nav (`meta.json`) and sidebar icon map (`page-icons.tsx`).

Scoped to the six connectors already merged on `api` main (`memsy_api/connectors/`) — excludes in-progress branches (ChatGPT, Gmail, Google Drive picker v2, etc.) that aren't live yet.

## Test plan
- [ ] Run the docs site locally (`cd docs && npm run dev`) and confirm the Connectors page renders under Integrations with the correct icon
- [ ] Spot-check each connector's env var list and scoping claim against `api/memsy_api/connectors/*.py`