### PR TITLE
Expose connector management (all providers) through the Python and Node SDKs

### DIFF
--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -206,7 +206,62 @@ await control.usage.summary();          // monthly usage roll-up (admin)
 await control.usage.timeseries({ ... }); // per-day series
 await control.billing.invoices();       // billing history (admin)
 await control.events.list({ ... });     // console event browser
+await control.connectors.list();        // knowledge-source connectors (admin)
 ```
+
+---
+
+## Connectors — `control.connectors`
+
+Connect knowledge sources — Slack, Google Drive, S3, Notion, GitHub, OneDrive — and choose what they sync.
+
+**Who may connect what.** Org-scoped providers (`slack`, `s3`, `notion`, `github`) are one shared connection per org: only an **org admin — or any API key, which the server treats as a service caller acting org-wide** — may connect, configure, sync or disconnect them. A seated non-admin member gets a 403 and may only read. User-scoped providers (`google_drive`, `onedrive`) are per-member: the owner manages their own connection, and an admin can see it for auditing but never mutate it. `requiresOrgAdmin(provider)` answers this client-side for pre-flight checks — the server is the enforcement point.
+
+```ts
+import { MemsyControlClient, requiresOrgAdmin } from "@memsy-io/memsy";
+
+const control = new MemsyControlClient({
+  baseUrl: process.env.MEMSY_CONTROL_URL!,
+  apiKey: process.env.MEMSY_API_KEY!,
+});
+
+await control.connectors.listProviders();
+// ["slack", "google_drive", "s3", "notion", "github", "onedrive"]
+requiresOrgAdmin("slack");        // true — admin/API key only
+requiresOrgAdmin("google_drive"); // false — per-member connection
+
+// 1. Start OAuth and send the end user to the consent screen
+const connection = await control.connectors.create("slack");
+console.log(connection.authorizeUrl);
+
+// 2. The provider redirects back to Memsy's own callback, which attaches the
+//    token. listResources() answers 409 until then, so poll:
+const resources = await control.connectors.waitUntilAuthorized(connection.connectorId);
+
+// 3. Pick what to sync — this activates the connector and starts the backfill.
+//    The selection replaces the previous one, so send the full set.
+await control.connectors.configureResources(connection.connectorId, resources);
+
+// Later
+await control.connectors.status("slack");        // member-safe: connected? (no ids)
+await control.connectors.list();                 // admin/API-key view
+await control.connectors.get(connectorId);       // status, lastSyncAt, lastError
+await control.connectors.sync(connectorId);      // manual refresh (must be active)
+await control.connectors.delete(connectorId);    // disconnect + revoke
+```
+
+Provider-specific bits:
+
+| Provider | Notes |
+|---|---|
+| `slack` | Org-scoped. `resourceType: "channel"`. |
+| `s3` | Org-scoped, **no OAuth** — `create()` returns 400. Use `configureS3({ accessKeyId, secretAccessKey, region, bucket })`, which validates the credentials, selects the bucket and starts the backfill in one call. |
+| `notion` | Org-scoped. `resourceType: "workspace"`. |
+| `github` | Org-scoped. `listResources()` returns repos (`resourceType: "repo"`); call `listBranches(connectorId, repo)` to expand one repo's branches lazily. |
+| `google_drive` | User-scoped. Drive can't enumerate server-side, so `listResources()` returns only what's already selected — real selection happens in the browser Google Picker via `pickerConfig(connectorId)`, then the chosen file ids go to `configureResources()`. |
+| `onedrive` | User-scoped. `listResources(connectorId, { parentId })` drills into folders. |
+
+> Gmail is deprecated and is no longer a registered provider.
 
 ---
 

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memsy-io/memsy",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Official Node.js SDK for the Memsy memory service",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/sdks/node/src/control.ts
+++ b/sdks/node/src/control.ts
@@ -5,6 +5,7 @@ import { UsageResource } from "./control_resources/usage.js";
 import { BillingResource } from "./control_resources/billing.js";
 import { EventsResource } from "./control_resources/events.js";
 import { InterestResource } from "./control_resources/interest.js";
+import { ConnectorsResource } from "./control_resources/connectors.js";
 
 export type MemsyControlClientOptions = BaseClientOptions;
 
@@ -22,6 +23,9 @@ export type MemsyControlClientOptions = BaseClientOptions;
  *   control.billing    — billing summary + invoices (admin-only)
  *   control.events     — raw event browsing (seat-required)
  *   control.interest   — Pro plan interest signaling
+ *   control.connectors — knowledge-source connectors (Slack, Google Drive,
+ *                        S3, Notion, GitHub, OneDrive). Org-scoped ones
+ *                        (Slack, S3, Notion, GitHub) are admin/API-key only.
  */
 export class MemsyControlClient extends BaseHttpClient {
   readonly keys: KeysResource;
@@ -29,6 +33,7 @@ export class MemsyControlClient extends BaseHttpClient {
   readonly billing: BillingResource;
   readonly events: EventsResource;
   readonly interest: InterestResource;
+  readonly connectors: ConnectorsResource;
 
   constructor(options: MemsyControlClientOptions) {
     super(options);
@@ -37,6 +42,7 @@ export class MemsyControlClient extends BaseHttpClient {
     this.billing = new BillingResource(this);
     this.events = new EventsResource(this);
     this.interest = new InterestResource(this);
+    this.connectors = new ConnectorsResource(this);
   }
 
   async me(): Promise<MeResponse> {

--- a/sdks/node/src/control_resources/connectors.ts
+++ b/sdks/node/src/control_resources/connectors.ts
@@ -1,0 +1,318 @@
+import type { BaseHttpClient } from "../http.js";
+import { MemsyAPIError } from "../errors.js";
+import {
+  type Connector,
+  type ConnectorConnection,
+  type ConnectorResourceItem,
+  type ConnectorStatus,
+  type PickerConfig,
+  type ResourceSelection,
+  parseConnector,
+  parseConnectorConnection,
+  parseConnectorResourceItem,
+  parseConnectorStatus,
+  parsePickerConfig,
+} from "../models.js";
+
+/** Providers where each member connects their own account. */
+export const USER_SCOPED_PROVIDERS: ReadonlySet<string> = new Set([
+  "google_drive",
+  "onedrive",
+]);
+
+/**
+ * Providers that are a single shared org resource — an org admin or an API key
+ * is required to connect or manage them. Advisory only; the server owns the
+ * real check and knows about providers newer than this SDK.
+ */
+export const ORG_SCOPED_PROVIDERS: ReadonlySet<string> = new Set([
+  "slack",
+  "s3",
+  "notion",
+  "github",
+]);
+
+/** Providers that don't use OAuth — use their dedicated configure method. */
+export const NON_OAUTH_PROVIDERS: ReadonlySet<string> = new Set(["s3"]);
+
+/**
+ * Whether connecting/managing `provider` needs an org admin or an API key.
+ *
+ * True for org-scoped providers (Slack, S3, Notion, GitHub), false for
+ * user-scoped ones (Google Drive, OneDrive). Use it to fail fast or hide UI —
+ * never as the security boundary; the server enforces it.
+ */
+export function requiresOrgAdmin(provider: string): boolean {
+  return !USER_SCOPED_PROVIDERS.has(provider);
+}
+
+export interface ConfigureS3Options {
+  accessKeyId: string;
+  secretAccessKey: string;
+  region: string;
+  bucket: string;
+  /** Only when re-configuring an existing S3 connector. */
+  connectorId?: string;
+}
+
+export interface WaitUntilAuthorizedOptions {
+  /** Give up after this many ms (default 300_000). */
+  timeoutMs?: number;
+  /** Delay between polls in ms (default 3_000). */
+  pollIntervalMs?: number;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function toSelectionBody(
+  resources: Array<ResourceSelection | ConnectorResourceItem>
+): Record<string, unknown> {
+  return {
+    resources: resources.map((r) => {
+      const body: Record<string, unknown> = {
+        external_id: r.externalId,
+        resource_type: r.resourceType ?? "channel",
+      };
+      if (r.name !== undefined && r.name !== null) body.name = r.name;
+      return body;
+    }),
+  };
+}
+
+/**
+ * Connector management (Slack, Google Drive, S3, Notion, GitHub, OneDrive).
+ *
+ * Two scoping models, and the difference decides who may connect what:
+ *
+ * - **Org-scoped** — `slack`, `s3`, `notion`, `github`. One shared connection
+ *   per org. **Only an org admin (or an API key, which the server treats as a
+ *   service caller acting org-wide) may connect, configure, sync or disconnect
+ *   one.** A seated non-admin member gets a 403 and may only read.
+ * - **User-scoped** — `google_drive`, `onedrive`. Each member connects their
+ *   own account; an org admin can see it for auditing but never mutate it.
+ *
+ * Typical OAuth flow:
+ * ```ts
+ * const connection = await control.connectors.create("slack");
+ * // send the end user to connection.authorizeUrl
+ * const resources = await control.connectors.waitUntilAuthorized(connection.connectorId);
+ * await control.connectors.configureResources(connection.connectorId, resources);
+ * ```
+ *
+ * S3 has no OAuth step — call {@link configureS3} instead of {@link create}.
+ */
+export class ConnectorsResource {
+  constructor(private readonly client: BaseHttpClient) {}
+
+  // ── discovery ──────────────────────────────────────────────────────────────
+
+  /** List provider slugs supported by this deployment. */
+  async listProviders(): Promise<string[]> {
+    const { data } = await this.client.request<Record<string, unknown>>(
+      "GET",
+      "/connectors/providers"
+    );
+    return (data?.providers as string[]) ?? [];
+  }
+
+  /**
+   * Whether a live connection exists for `provider`. Member-safe — use this
+   * instead of {@link list} when the caller may not be an org admin.
+   */
+  async status(provider: string): Promise<ConnectorStatus> {
+    const { data } = await this.client.request<Record<string, unknown>>(
+      "GET",
+      `/connectors/${encodeURIComponent(provider)}/status`
+    );
+    return parseConnectorStatus(data);
+  }
+
+  // ── connecting ─────────────────────────────────────────────────────────────
+
+  /**
+   * Start an OAuth connection for a provider.
+   *
+   * Send the end user to the returned `authorizeUrl`. The provider redirects
+   * back to Memsy's own callback (not to you), which exchanges the code and
+   * attaches the token; the connector stays `pending` until resources are
+   * selected. Poll {@link get} — or use {@link waitUntilAuthorized}.
+   *
+   * Throws 400 if the provider doesn't use OAuth (S3 — use {@link configureS3}),
+   * 403 if an org-scoped provider is connected by a non-admin, 409 if a
+   * workspace is already connected.
+   */
+  async create(provider: string): Promise<ConnectorConnection> {
+    const { data } = await this.client.request<Record<string, unknown>>(
+      "POST",
+      `/connectors/${encodeURIComponent(provider)}/connect`
+    );
+    return parseConnectorConnection(data);
+  }
+
+  /**
+   * Connect (or re-configure) S3 with direct IAM credentials — no OAuth.
+   *
+   * Credentials are validated before anything is stored, the bucket is
+   * auto-selected as the only resource, and the backfill starts immediately.
+   * Org-scoped: admins / API keys only.
+   */
+  async configureS3(options: ConfigureS3Options): Promise<Connector> {
+    const body: Record<string, unknown> = {
+      access_key_id: options.accessKeyId,
+      secret_access_key: options.secretAccessKey,
+      region: options.region,
+      bucket: options.bucket,
+    };
+    if (options.connectorId !== undefined) body.connector_id = options.connectorId;
+    const { data } = await this.client.request<Record<string, unknown>>(
+      "POST",
+      "/connectors/s3/configure",
+      { body }
+    );
+    return parseConnector(data);
+  }
+
+  // ── reading ────────────────────────────────────────────────────────────────
+
+  /**
+   * List connectors visible to the caller for this org. Non-admin members see
+   * only their own user-scoped connections.
+   */
+  async list(): Promise<Connector[]> {
+    const { data } = await this.client.request<Record<string, unknown>[]>(
+      "GET",
+      "/connectors"
+    );
+    return (data ?? []).map(parseConnector);
+  }
+
+  /** Retrieve a single connector. */
+  async get(connectorId: string): Promise<Connector> {
+    const { data } = await this.client.request<Record<string, unknown>>(
+      "GET",
+      `/connectors/${encodeURIComponent(connectorId)}`
+    );
+    return parseConnector(data);
+  }
+
+  /**
+   * List resources available on a connector, each flagged `selected`.
+   *
+   * Pass `parentId` to drill into a folder (OneDrive). Throws 409 while the
+   * OAuth token hasn't been attached yet — that's the signal to keep polling,
+   * see {@link waitUntilAuthorized}.
+   */
+  async listResources(
+    connectorId: string,
+    options: { parentId?: string } = {}
+  ): Promise<ConnectorResourceItem[]> {
+    const { data } = await this.client.request<Record<string, unknown>>(
+      "GET",
+      `/connectors/${encodeURIComponent(connectorId)}/resources`,
+      { query: { parent_id: options.parentId } }
+    );
+    return ((data?.resources as Record<string, unknown>[]) ?? []).map(
+      parseConnectorResourceItem
+    );
+  }
+
+  /**
+   * GitHub only: list branches for one repo (`repo` is a repo container's
+   * `externalId` from {@link listResources}). Listed lazily per repo so a large
+   * account's repo list never fans out over every branch.
+   */
+  async listBranches(connectorId: string, repo: string): Promise<ConnectorResourceItem[]> {
+    const { data } = await this.client.request<Record<string, unknown>>(
+      "GET",
+      `/connectors/${encodeURIComponent(connectorId)}/branches`,
+      { query: { repo } }
+    );
+    return ((data?.resources as Record<string, unknown>[]) ?? []).map(
+      parseConnectorResourceItem
+    );
+  }
+
+  /**
+   * Google Drive only: mint a short-lived token + config for the browser Google
+   * Picker. Owner-only — an admin cannot mint one for someone else.
+   */
+  async pickerConfig(connectorId: string): Promise<PickerConfig> {
+    const { data } = await this.client.request<Record<string, unknown>>(
+      "GET",
+      `/connectors/${encodeURIComponent(connectorId)}/picker-token`
+    );
+    return parsePickerConfig(data);
+  }
+
+  /**
+   * Block until the end user finishes the provider's consent screen.
+   *
+   * `listResources` answers 409 until the OAuth callback has attached the
+   * token, so this polls it and resolves with the resources once it succeeds.
+   * Rejects with an Error if consent isn't completed within the timeout.
+   */
+  async waitUntilAuthorized(
+    connectorId: string,
+    options: WaitUntilAuthorizedOptions = {}
+  ): Promise<ConnectorResourceItem[]> {
+    const timeoutMs = options.timeoutMs ?? 300_000;
+    const pollIntervalMs = options.pollIntervalMs ?? 3_000;
+    const deadline = Date.now() + timeoutMs;
+
+    for (;;) {
+      try {
+        return await this.listResources(connectorId);
+      } catch (err) {
+        if (!(err instanceof MemsyAPIError) || err.statusCode !== 409) throw err;
+        if (Date.now() + pollIntervalMs >= deadline) {
+          throw new Error(
+            `Connector ${connectorId} was not authorized within ${timeoutMs}ms`
+          );
+        }
+        await sleep(pollIntervalMs);
+      }
+    }
+  }
+
+  // ── managing ───────────────────────────────────────────────────────────────
+
+  /**
+   * Select which resources to sync and trigger an immediate backfill. This also
+   * flips the connector from `pending` to `active`. The selection **replaces**
+   * the current one — send the full set every time.
+   *
+   * Accepts `ResourceSelection`s or the items returned by {@link listResources}.
+   *
+   * Org-scoped connectors: admins / API keys only. User-scoped: owner only.
+   */
+  async configureResources(
+    connectorId: string,
+    resources: Array<ResourceSelection | ConnectorResourceItem>
+  ): Promise<Connector> {
+    const { data } = await this.client.request<Record<string, unknown>>(
+      "PUT",
+      `/connectors/${encodeURIComponent(connectorId)}/resources`,
+      { body: toSelectionBody(resources) }
+    );
+    return parseConnector(data);
+  }
+
+  /** Trigger an immediate sync. 409 unless the connector is `active`. */
+  async sync(connectorId: string): Promise<Connector> {
+    const { data } = await this.client.request<Record<string, unknown>>(
+      "POST",
+      `/connectors/${encodeURIComponent(connectorId)}/sync`
+    );
+    return parseConnector(data);
+  }
+
+  /** Disconnect and revoke the connector's stored credentials. */
+  async delete(connectorId: string): Promise<void> {
+    await this.client.request<null>(
+      "DELETE",
+      `/connectors/${encodeURIComponent(connectorId)}`
+    );
+  }
+}

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -24,6 +24,17 @@ export { EventsResource } from "./control_resources/events.js";
 export type { ConsoleEventListOptions } from "./control_resources/events.js";
 export { InterestResource } from "./control_resources/interest.js";
 export type { InterestExpressOptions } from "./control_resources/interest.js";
+export {
+  ConnectorsResource,
+  USER_SCOPED_PROVIDERS,
+  ORG_SCOPED_PROVIDERS,
+  NON_OAUTH_PROVIDERS,
+  requiresOrgAdmin,
+} from "./control_resources/connectors.js";
+export type {
+  ConfigureS3Options,
+  WaitUntilAuthorizedOptions,
+} from "./control_resources/connectors.js";
 
 // ── Models ───────────────────────────────────────────────────────────────────
 export type {
@@ -65,6 +76,13 @@ export type {
   EventItem,
   EventListResponse,
   ProInterestResponse,
+  // Connectors
+  Connector,
+  ConnectorConnection,
+  ConnectorResourceItem,
+  ResourceSelection,
+  ConnectorStatus,
+  PickerConfig,
 } from "./models.js";
 
 // ── Errors ───────────────────────────────────────────────────────────────────

--- a/sdks/node/src/models.ts
+++ b/sdks/node/src/models.ts
@@ -669,3 +669,126 @@ export interface ProInterestResponse {
 export function parseProInterestResponse(d: Record<string, unknown>): ProInterestResponse {
   return { message: String(d.message ?? "") };
 }
+
+// ── Connectors (control plane) ───────────────────────────────────────────────
+
+/** Response from initiating a connector OAuth flow. */
+export interface ConnectorConnection {
+  connectorId: string;
+  /** Send the end user here to complete the provider's consent screen. */
+  authorizeUrl: string;
+}
+
+/** A connected data source (Slack, Google Drive, S3, Notion, GitHub, OneDrive). */
+export interface Connector {
+  id: string;
+  provider: string;
+  status: string;
+  displayName: string | null;
+  externalAccountId: string | null;
+  configuredByEmail: string | null;
+  scopes: string[];
+  lastSyncAt: string | null;
+  nextSyncAt: string | null;
+  lastError: string | null;
+  createdAt: string;
+  /** S3 only; null for every other provider. */
+  bucket: string | null;
+  /** S3 only; null for every other provider. */
+  region: string | null;
+}
+
+/**
+ * A resource available on a connector, with its current selection state.
+ *
+ * `resourceType` is provider-specific: `channel` (Slack), `bucket` (S3),
+ * `workspace` (Notion), `repo` / `branch` / `default_branch` (GitHub),
+ * `folder` / `file` (OneDrive, Google Drive).
+ */
+export interface ConnectorResourceItem {
+  externalId: string;
+  resourceType: string;
+  name: string | null;
+  selected: boolean;
+}
+
+/**
+ * A resource to enable syncing for, passed to `configureResources`.
+ *
+ * Carry `resourceType` through from `listResources()` rather than guessing —
+ * the provider relies on it.
+ */
+export interface ResourceSelection {
+  externalId: string;
+  resourceType?: string;
+  name?: string | null;
+}
+
+/** Member-safe connection status for a provider (no ids, no secrets). */
+export interface ConnectorStatus {
+  connected: boolean;
+  displayName: string | null;
+}
+
+/**
+ * Google Drive only: short-lived credentials for opening the Google Picker in
+ * a browser. `accessToken` is a live Google credential — never log it.
+ */
+export interface PickerConfig {
+  accessToken: string;
+  expiresIn: number;
+  apiKey: string;
+  appId: string;
+}
+
+export function parseConnectorConnection(d: Record<string, unknown>): ConnectorConnection {
+  return {
+    connectorId: String(d.connector_id),
+    authorizeUrl: String(d.authorize_url),
+  };
+}
+
+export function parseConnector(d: Record<string, unknown>): Connector {
+  return {
+    id: String(d.id),
+    provider: String(d.provider),
+    status: String(d.status),
+    displayName: asStringOrNull(d.display_name),
+    externalAccountId: asStringOrNull(d.external_account_id),
+    configuredByEmail: asStringOrNull(d.configured_by_email),
+    scopes: (d.scopes as string[]) ?? [],
+    lastSyncAt: asStringOrNull(d.last_sync_at),
+    nextSyncAt: asStringOrNull(d.next_sync_at),
+    lastError: asStringOrNull(d.last_error),
+    createdAt: String(d.created_at),
+    bucket: asStringOrNull(d.bucket),
+    region: asStringOrNull(d.region),
+  };
+}
+
+export function parseConnectorResourceItem(
+  d: Record<string, unknown>
+): ConnectorResourceItem {
+  return {
+    externalId: String(d.external_id),
+    resourceType: typeof d.resource_type === "string" ? d.resource_type : "channel",
+    name: asStringOrNull(d.name),
+    selected: Boolean(d.selected),
+  };
+}
+
+export function parseConnectorStatus(d: Record<string, unknown>): ConnectorStatus {
+  return {
+    connected: Boolean(d.connected),
+    displayName: asStringOrNull(d.display_name),
+  };
+}
+
+export function parsePickerConfig(d: Record<string, unknown>): PickerConfig {
+  return {
+    accessToken: String(d.access_token),
+    expiresIn: Number(d.expires_in ?? 0),
+    apiKey: String(d.api_key),
+    appId: String(d.app_id),
+  };
+}

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -311,6 +311,68 @@ records = control.keys.usage(new_key.key_id)
 control.keys.delete(new_key.key_id)
 ```
 
+### `control.connectors`
+
+Connect knowledge sources — Slack, Google Drive, S3, Notion, GitHub, OneDrive —
+and choose what they sync.
+
+**Who may connect what.** 
+Org-scoped providers (`slack`, `s3`, `notion`,
+`github`) are one shared connection per org: only an **org admin — or any API
+key, which the server treats as a service caller acting org-wide** — may
+connect, configure, sync or disconnect them. A seated non-admin member gets
+`AuthorizationError` (403) and may only read. User-scoped providers
+(`google_drive`, `onedrive`) are per-member: the owner manages their own
+connection, and an admin can see it for auditing but never mutate it.
+`requires_org_admin(provider)` answers this client-side for pre-flight checks —
+the server is the enforcement point.
+
+```python
+from memsy import MemsyControlClient, ResourceSelection, requires_org_admin
+
+control = MemsyControlClient(base_url=MEMSY_CONTROL_URL, api_key=MEMSY_API_KEY)
+
+control.connectors.list_providers()
+# ['slack', 'google_drive', 's3', 'notion', 'github', 'onedrive']
+requires_org_admin("slack")         # True — admin/API key only
+requires_org_admin("google_drive")  # False — per-member connection
+
+# 1. Start OAuth and send the end user to the consent screen
+connection = control.connectors.create("slack")
+print(connection.authorize_url)
+
+# 2. The provider redirects back to Memsy's own callback, which attaches the
+#    token. list_resources() answers 409 until then, so poll:
+resources = control.connectors.wait_until_authorized(connection.connector_id)
+
+# 3. Pick what to sync — this activates the connector and starts the backfill.
+#    The selection replaces the previous one, so send the full set.
+control.connectors.configure_resources(
+    connection.connector_id,
+    [ResourceSelection.from_item(r) for r in resources if r.name != "random"],
+)
+
+# Later
+control.connectors.status("slack")            # member-safe: connected? (no ids)
+control.connectors.list()                     # admin/API-key view
+control.connectors.get(connector_id)          # status, last_sync_at, last_error
+control.connectors.sync(connector_id)         # manual refresh (must be active)
+control.connectors.delete(connector_id)       # disconnect + revoke
+```
+
+Provider-specific bits:
+
+| Provider | Notes |
+|---|---|
+| `slack` | Org-scoped. `resource_type="channel"`. |
+| `s3` | Org-scoped, **no OAuth** — `create()` returns 400. Use `configure_s3(access_key_id=..., secret_access_key=..., region=..., bucket=...)`, which validates the credentials, selects the bucket and starts the backfill in one call. |
+| `notion` | Org-scoped. `resource_type="workspace"`. |
+| `github` | Org-scoped. `list_resources()` returns repos (`resource_type="repo"`); call `list_branches(connector_id, repo=...)` to expand one repo's branches lazily. |
+| `google_drive` | User-scoped. Drive can't enumerate server-side, so `list_resources()` returns only what's already selected — real selection happens in the browser Google Picker via `picker_config(connector_id)`, then the chosen file ids go to `configure_resources()`. |
+| `onedrive` | User-scoped. `list_resources(connector_id, parent_id=...)` drills into folders. |
+
+> Gmail is deprecated and is no longer a registered provider.
+
 ### `control.interest`
 
 ```python

--- a/sdks/python/memsy/__init__.py
+++ b/sdks/python/memsy/__init__.py
@@ -23,13 +23,16 @@ Quick start::
     client.roles.list(org_id="my-org")
     client.memories.stats()
 
-Control-plane (billing, keys, usage, events)::
+Control-plane (billing, keys, usage, events, connectors)::
 
     from memsy import MemsyControlClient
 
     control = MemsyControlClient(base_url="https://your-api-url", api_key="msy_...")
     me = control.me()
     events = control.events.list(limit=20)
+
+    # Connect a knowledge source (Slack, Google Drive, S3, Notion, GitHub, OneDrive)
+    connection = control.connectors.create("slack")
 
 Async usage::
 
@@ -43,6 +46,11 @@ from memsy.async_client import AsyncMemsyClient
 from memsy.async_control import AsyncMemsyControlClient
 from memsy.client import MemsyClient
 from memsy.control import MemsyControlClient
+from memsy.control_resources.connectors import (
+    ORG_SCOPED_PROVIDERS,
+    USER_SCOPED_PROVIDERS,
+    requires_org_admin,
+)
 from memsy.exceptions import (
     AuthenticationError,
     AuthorizationError,
@@ -64,6 +72,11 @@ from memsy.models import (
     ApiKeyInfo,
     ApiKeyListResponse,
     BillingSummary,
+    # Connector models
+    Connector,
+    ConnectorConnection,
+    ConnectorResourceItem,
+    ConnectorStatus,
     CreateKeyResponse,
     DimensionUsage,
     EventItemResponse,
@@ -82,8 +95,10 @@ from memsy.models import (
     # Onboarding models
     OrgResource,
     PaymentMethod,
+    PickerConfig,
     ProInterestResponse,
     RateLimitInfo,
+    ResourceSelection,
     RoleResource,
     SearchResponse,
     SearchResult,
@@ -137,6 +152,16 @@ __all__ = [
     "EventItemResponse",
     "EventListResponse",
     "ProInterestResponse",
+    # Connector models
+    "ConnectorConnection",
+    "Connector",
+    "ConnectorResourceItem",
+    "ResourceSelection",
+    "ConnectorStatus",
+    "PickerConfig",
+    "USER_SCOPED_PROVIDERS",
+    "ORG_SCOPED_PROVIDERS",
+    "requires_org_admin",
     # Usage & Rate Limit
     "UsageInfo",
     "RateLimitInfo",

--- a/sdks/python/memsy/async_control.py
+++ b/sdks/python/memsy/async_control.py
@@ -7,6 +7,7 @@ import httpx
 
 from memsy._http import DEFAULT_MAX_RETRIES, DEFAULT_RETRY_BACKOFF, HttpCoreMixin
 from memsy.control_resources.billing import AsyncBillingResource
+from memsy.control_resources.connectors import AsyncConnectorsResource
 from memsy.control_resources.events import AsyncEventsResource
 from memsy.control_resources.interest import AsyncInterestResource
 from memsy.control_resources.keys import AsyncKeysResource
@@ -41,6 +42,7 @@ class AsyncMemsyControlClient(HttpCoreMixin):
         control.keys        — AsyncKeysResource
         control.events      — AsyncEventsResource
         control.interest    — AsyncInterestResource
+        control.connectors  — AsyncConnectorsResource
     """
 
     def __init__(
@@ -65,6 +67,7 @@ class AsyncMemsyControlClient(HttpCoreMixin):
         self.keys = AsyncKeysResource(self)
         self.events = AsyncEventsResource(self)
         self.interest = AsyncInterestResource(self)
+        self.connectors = AsyncConnectorsResource(self)
 
     async def __aenter__(self) -> AsyncMemsyControlClient:
         return self

--- a/sdks/python/memsy/control.py
+++ b/sdks/python/memsy/control.py
@@ -7,6 +7,7 @@ import httpx
 
 from memsy._http import DEFAULT_MAX_RETRIES, DEFAULT_RETRY_BACKOFF, HttpCoreMixin
 from memsy.control_resources.billing import BillingResource
+from memsy.control_resources.connectors import ConnectorsResource
 from memsy.control_resources.events import EventsResource
 from memsy.control_resources.interest import InterestResource
 from memsy.control_resources.keys import KeysResource
@@ -40,6 +41,12 @@ class MemsyControlClient(HttpCoreMixin):
         invoices = control.billing.invoices()
         key = control.keys.create("ci-key", scopes=["read"])
 
+        # Connectors (Slack, Google Drive, S3, Notion, GitHub, OneDrive).
+        # Org-scoped ones (Slack, S3, Notion, GitHub) need an org admin or
+        # an API key; Drive/OneDrive are per-member connections.
+        connection = control.connectors.create("slack")
+        print(connection.authorize_url)  # send the end user here
+
     Sub-resource accessors::
 
         control.usage       — UsageResource
@@ -47,6 +54,7 @@ class MemsyControlClient(HttpCoreMixin):
         control.keys        — KeysResource
         control.events      — EventsResource
         control.interest    — InterestResource
+        control.connectors  — ConnectorsResource
     """
 
     def __init__(
@@ -71,6 +79,7 @@ class MemsyControlClient(HttpCoreMixin):
         self.keys = KeysResource(self)
         self.events = EventsResource(self)
         self.interest = InterestResource(self)
+        self.connectors = ConnectorsResource(self)
 
     def __enter__(self) -> MemsyControlClient:
         return self

--- a/sdks/python/memsy/control_resources/__init__.py
+++ b/sdks/python/memsy/control_resources/__init__.py
@@ -1,4 +1,11 @@
 from memsy.control_resources.billing import AsyncBillingResource, BillingResource
+from memsy.control_resources.connectors import (
+    ORG_SCOPED_PROVIDERS,
+    USER_SCOPED_PROVIDERS,
+    AsyncConnectorsResource,
+    ConnectorsResource,
+    requires_org_admin,
+)
 from memsy.control_resources.events import AsyncEventsResource, EventsResource
 from memsy.control_resources.interest import AsyncInterestResource, InterestResource
 from memsy.control_resources.keys import AsyncKeysResource, KeysResource
@@ -15,4 +22,9 @@ __all__ = [
     "AsyncEventsResource",
     "InterestResource",
     "AsyncInterestResource",
+    "ConnectorsResource",
+    "AsyncConnectorsResource",
+    "USER_SCOPED_PROVIDERS",
+    "ORG_SCOPED_PROVIDERS",
+    "requires_org_admin",
 ]

--- a/sdks/python/memsy/control_resources/connectors.py
+++ b/sdks/python/memsy/control_resources/connectors.py
@@ -1,0 +1,427 @@
+"""Connector management (Slack, Google Drive, S3, Notion, GitHub, OneDrive).
+
+Connectors live on the control plane (``api/``), so they hang off
+:class:`~memsy.control.MemsyControlClient`, not ``MemsyClient``.
+
+Two scoping models, and the difference decides who may connect what:
+
+* **Org-scoped** — ``slack``, ``s3``, ``notion``, ``github``. One shared
+  connection per org. **Only an org admin (or an API key, which the server
+  treats as a service caller acting org-wide) may connect, configure, sync or
+  disconnect one.** A seated non-admin member gets ``AuthorizationError``
+  (HTTP 403) — they may only *read*.
+* **User-scoped** — ``google_drive``, ``onedrive``. Each member connects their
+  own account. The owner manages their own connection; an org admin can see it
+  for auditing but may never mutate it or spend its token.
+
+The server is the enforcement point (``api/memsy_api/http/routes/connectors.py``);
+:func:`requires_org_admin` is only a pre-flight convenience so callers can fail
+fast or hide UI — never treat it as the security boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING, Any
+
+from memsy.exceptions import MemsyAPIError
+from memsy.models import (
+    Connector,
+    ConnectorConnection,
+    ConnectorResourceItem,
+    ConnectorStatus,
+    PickerConfig,
+    ResourceSelection,
+)
+
+if TYPE_CHECKING:
+    from memsy.async_control import AsyncMemsyControlClient
+    from memsy.control import MemsyControlClient
+
+#: Providers where each member connects their own account.
+USER_SCOPED_PROVIDERS: frozenset[str] = frozenset({"google_drive", "onedrive"})
+
+#: Providers that are a single shared org resource — admin/service-key only to
+#: connect or manage. Kept as a hint for callers; the server owns the real check
+#: (and knows about providers newer than this SDK).
+ORG_SCOPED_PROVIDERS: frozenset[str] = frozenset({"slack", "s3", "notion", "github"})
+
+#: Providers that do not use OAuth — use their dedicated configure method.
+NON_OAUTH_PROVIDERS: frozenset[str] = frozenset({"s3"})
+
+#: How often ``wait_until_authorized`` polls, in seconds.
+_POLL_INTERVAL = 3.0
+
+
+def requires_org_admin(provider: str) -> bool:
+    """Whether connecting/managing ``provider`` needs an org admin or API key.
+
+    True for org-scoped providers (Slack, S3, Notion, GitHub), False for
+    user-scoped ones (Google Drive, OneDrive). Advisory only — the server
+    enforces this and is authoritative for providers this SDK doesn't know.
+    """
+    return provider not in USER_SCOPED_PROVIDERS
+
+
+def _selection_body(
+    resources: list[ResourceSelection] | list[ConnectorResourceItem],
+) -> dict[str, Any]:
+    items = [
+        r if isinstance(r, ResourceSelection) else ResourceSelection.from_item(r) for r in resources
+    ]
+    return {"resources": [r.to_dict() for r in items]}
+
+
+def _s3_body(
+    access_key_id: str,
+    secret_access_key: str,
+    region: str,
+    bucket: str,
+    connector_id: str | None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "access_key_id": access_key_id,
+        "secret_access_key": secret_access_key,
+        "region": region,
+        "bucket": bucket,
+    }
+    if connector_id is not None:
+        body["connector_id"] = connector_id
+    return body
+
+
+class ConnectorsResource:
+    """Sync wrapper for the control-plane ``/connectors`` endpoints.
+
+    Typical OAuth flow (Slack, Notion, GitHub, Google Drive, OneDrive)::
+
+        connection = control.connectors.create("slack")
+        # send the end user to connection.authorize_url and let them consent
+        resources = control.connectors.wait_until_authorized(connection.connector_id)
+        control.connectors.configure_resources(
+            connection.connector_id,
+            [ResourceSelection.from_item(r) for r in resources],
+        )
+
+    S3 has no OAuth step — call :meth:`configure_s3` instead of :meth:`create`.
+
+    See the module docstring for who is allowed to do what: org-scoped
+    providers are admin/service-key only.
+    """
+
+    def __init__(self, client: MemsyControlClient) -> None:
+        self._client = client
+
+    # -- discovery -----------------------------------------------------------
+
+    def list_providers(self) -> list[str]:
+        """List provider slugs supported by this deployment."""
+        data, _, _ = self._client._request("GET", "/connectors/providers")
+        return data.get("providers", [])
+
+    def status(self, provider: str) -> ConnectorStatus:
+        """Whether a live connection exists for ``provider``.
+
+        Member-safe — use this instead of :meth:`list` when the caller may not
+        be an org admin.
+        """
+        data, _, _ = self._client._request("GET", f"/connectors/{provider}/status")
+        return ConnectorStatus.from_dict(data)
+
+    # -- connecting ----------------------------------------------------------
+
+    def create(self, provider: str) -> ConnectorConnection:
+        """
+        Start an OAuth connection for a provider.
+
+        Send the end user to the returned ``authorize_url``. The provider
+        redirects back to Memsy's own callback (not to you), which exchanges the
+        code and attaches the token; the connector stays ``pending`` until
+        resources are selected. Poll :meth:`get` — or use
+        :meth:`wait_until_authorized` — to learn when the token has landed.
+
+        :param provider: A slug from :meth:`list_providers` (e.g. ``"slack"``).
+        :raises MemsyAPIError: 400 if the provider doesn't use OAuth (S3 — use
+            :meth:`configure_s3`), 403 if an org-scoped provider is being
+            connected by a non-admin, 409 if a workspace is already connected.
+        """
+        data, _, _ = self._client._request("POST", f"/connectors/{provider}/connect")
+        return ConnectorConnection.from_dict(data)
+
+    def configure_s3(
+        self,
+        *,
+        access_key_id: str,
+        secret_access_key: str,
+        region: str,
+        bucket: str,
+        connector_id: str | None = None,
+    ) -> Connector:
+        """
+        Connect (or re-configure) S3 with direct IAM credentials — no OAuth.
+
+        Credentials are validated before anything is stored, the bucket is
+        auto-selected as the only resource, and the backfill sync starts
+        immediately, so this single call fully wires the connection.
+
+        Org-scoped: admins / API keys only.
+
+        :param connector_id: Only when re-configuring an existing S3 connector.
+        """
+        data, _, _ = self._client._request(
+            "POST",
+            "/connectors/s3/configure",
+            json=_s3_body(access_key_id, secret_access_key, region, bucket, connector_id),
+        )
+        return Connector.from_dict(data)
+
+    # -- reading -------------------------------------------------------------
+
+    def list(self) -> list[Connector]:
+        """List connectors visible to the caller for this org.
+
+        Non-admin members see only their own user-scoped connections.
+        """
+        data, _, _ = self._client._request("GET", "/connectors")
+        return [Connector.from_dict(c) for c in (data or [])]
+
+    def get(self, connector_id: str) -> Connector:
+        """Retrieve a single connector."""
+        data, _, _ = self._client._request("GET", f"/connectors/{connector_id}")
+        return Connector.from_dict(data)
+
+    def list_resources(
+        self, connector_id: str, *, parent_id: str | None = None
+    ) -> list[ConnectorResourceItem]:
+        """List resources available on a connector, each flagged ``selected``.
+
+        :param parent_id: Drill into a folder (OneDrive). Providers that don't
+            support navigation return 400.
+        :raises MemsyAPIError: 409 while the OAuth token hasn't been attached
+            yet — that's the signal to keep polling, see
+            :meth:`wait_until_authorized`.
+        """
+        params = {"parent_id": parent_id} if parent_id is not None else None
+        data, _, _ = self._client._request(
+            "GET", f"/connectors/{connector_id}/resources", params=params
+        )
+        return [ConnectorResourceItem.from_dict(r) for r in data.get("resources", [])]
+
+    def list_branches(self, connector_id: str, repo: str) -> list[ConnectorResourceItem]:
+        """GitHub only: list branches for one repo (``repo`` is a repo
+        container's ``external_id`` from :meth:`list_resources`).
+
+        Listed lazily per repo so a large account's repo list never fans out
+        over every branch. 400 on providers without branch support.
+        """
+        data, _, _ = self._client._request(
+            "GET", f"/connectors/{connector_id}/branches", params={"repo": repo}
+        )
+        return [ConnectorResourceItem.from_dict(r) for r in data.get("resources", [])]
+
+    def picker_config(self, connector_id: str) -> PickerConfig:
+        """Google Drive only: mint a short-lived token + config for the browser
+        Google Picker. Owner-only — an admin cannot mint one for someone else.
+        """
+        data, _, _ = self._client._request("GET", f"/connectors/{connector_id}/picker-token")
+        return PickerConfig.from_dict(data)
+
+    def wait_until_authorized(
+        self,
+        connector_id: str,
+        *,
+        timeout: float = 300.0,
+        poll_interval: float = _POLL_INTERVAL,
+    ) -> list[ConnectorResourceItem]:
+        """Block until the end user finishes the provider's consent screen.
+
+        ``list_resources`` answers 409 until the OAuth callback has attached the
+        token, so this polls it and returns the resources once it succeeds.
+
+        :raises TimeoutError: if the user never completes consent in time.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                return self.list_resources(connector_id)
+            except MemsyAPIError as exc:
+                if exc.status_code != 409:
+                    raise
+                if time.monotonic() + poll_interval >= deadline:
+                    raise TimeoutError(
+                        f"Connector {connector_id} was not authorized within {timeout}s"
+                    ) from exc
+                time.sleep(poll_interval)
+
+    # -- managing ------------------------------------------------------------
+
+    def configure_resources(
+        self,
+        connector_id: str,
+        resources: list[ResourceSelection] | list[ConnectorResourceItem],
+    ) -> Connector:
+        """
+        Select which resources to sync and trigger an immediate backfill.
+
+        This also flips the connector from ``pending`` to ``active``. The
+        selection **replaces** the current one — send the full set every time.
+
+        Accepts :class:`~memsy.models.ResourceSelection` objects or the
+        :class:`~memsy.models.ConnectorResourceItem` values returned by
+        :meth:`list_resources` (converted for you, preserving ``resource_type``).
+
+        Org-scoped connectors: admins / API keys only. User-scoped: owner only.
+        """
+        data, _, _ = self._client._request(
+            "PUT", f"/connectors/{connector_id}/resources", json=_selection_body(resources)
+        )
+        return Connector.from_dict(data)
+
+    def sync(self, connector_id: str) -> Connector:
+        """Trigger an immediate sync. 409 unless the connector is ``active``."""
+        data, _, _ = self._client._request("POST", f"/connectors/{connector_id}/sync")
+        return Connector.from_dict(data)
+
+    def delete(self, connector_id: str) -> None:
+        """Disconnect and revoke the connector's stored credentials."""
+        self._client._request("DELETE", f"/connectors/{connector_id}")
+
+
+class AsyncConnectorsResource:
+    """Async wrapper for the control-plane ``/connectors`` endpoints.
+
+    Mirrors :class:`ConnectorsResource` method-for-method; see it and the module
+    docstring for flow and permission details.
+    """
+
+    def __init__(self, client: AsyncMemsyControlClient) -> None:
+        self._client = client
+
+    # -- discovery -----------------------------------------------------------
+
+    async def list_providers(self) -> list[str]:
+        """List provider slugs supported by this deployment."""
+        data, _, _ = await self._client._request("GET", "/connectors/providers")
+        return data.get("providers", [])
+
+    async def status(self, provider: str) -> ConnectorStatus:
+        """Whether a live connection exists for ``provider`` (member-safe)."""
+        data, _, _ = await self._client._request("GET", f"/connectors/{provider}/status")
+        return ConnectorStatus.from_dict(data)
+
+    # -- connecting ----------------------------------------------------------
+
+    async def create(self, provider: str) -> ConnectorConnection:
+        """Start an OAuth connection; send the user to ``authorize_url``.
+
+        Org-scoped providers (Slack, Notion, GitHub) require an org admin or an
+        API key. S3 doesn't use OAuth — call :meth:`configure_s3`.
+        """
+        data, _, _ = await self._client._request("POST", f"/connectors/{provider}/connect")
+        return ConnectorConnection.from_dict(data)
+
+    async def configure_s3(
+        self,
+        *,
+        access_key_id: str,
+        secret_access_key: str,
+        region: str,
+        bucket: str,
+        connector_id: str | None = None,
+    ) -> Connector:
+        """Connect (or re-configure) S3 with direct IAM credentials — no OAuth.
+
+        Org-scoped: admins / API keys only.
+        """
+        data, _, _ = await self._client._request(
+            "POST",
+            "/connectors/s3/configure",
+            json=_s3_body(access_key_id, secret_access_key, region, bucket, connector_id),
+        )
+        return Connector.from_dict(data)
+
+    # -- reading -------------------------------------------------------------
+
+    async def list(self) -> list[Connector]:
+        """List connectors visible to the caller for this org."""
+        data, _, _ = await self._client._request("GET", "/connectors")
+        return [Connector.from_dict(c) for c in (data or [])]
+
+    async def get(self, connector_id: str) -> Connector:
+        """Retrieve a single connector."""
+        data, _, _ = await self._client._request("GET", f"/connectors/{connector_id}")
+        return Connector.from_dict(data)
+
+    async def list_resources(
+        self, connector_id: str, *, parent_id: str | None = None
+    ) -> list[ConnectorResourceItem]:
+        """List resources available on a connector, each flagged ``selected``.
+
+        409 until the OAuth token has been attached — see
+        :meth:`wait_until_authorized`.
+        """
+        params = {"parent_id": parent_id} if parent_id is not None else None
+        data, _, _ = await self._client._request(
+            "GET", f"/connectors/{connector_id}/resources", params=params
+        )
+        return [ConnectorResourceItem.from_dict(r) for r in data.get("resources", [])]
+
+    async def list_branches(self, connector_id: str, repo: str) -> list[ConnectorResourceItem]:
+        """GitHub only: list branches for one repo."""
+        data, _, _ = await self._client._request(
+            "GET", f"/connectors/{connector_id}/branches", params={"repo": repo}
+        )
+        return [ConnectorResourceItem.from_dict(r) for r in data.get("resources", [])]
+
+    async def picker_config(self, connector_id: str) -> PickerConfig:
+        """Google Drive only: mint a short-lived token for the browser Picker."""
+        data, _, _ = await self._client._request("GET", f"/connectors/{connector_id}/picker-token")
+        return PickerConfig.from_dict(data)
+
+    async def wait_until_authorized(
+        self,
+        connector_id: str,
+        *,
+        timeout: float = 300.0,
+        poll_interval: float = _POLL_INTERVAL,
+    ) -> list[ConnectorResourceItem]:
+        """Await the end user finishing consent, then return the resources.
+
+        :raises TimeoutError: if consent isn't completed in time.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                return await self.list_resources(connector_id)
+            except MemsyAPIError as exc:
+                if exc.status_code != 409:
+                    raise
+                if time.monotonic() + poll_interval >= deadline:
+                    raise TimeoutError(
+                        f"Connector {connector_id} was not authorized within {timeout}s"
+                    ) from exc
+                await asyncio.sleep(poll_interval)
+
+    # -- managing ------------------------------------------------------------
+
+    async def configure_resources(
+        self,
+        connector_id: str,
+        resources: list[ResourceSelection] | list[ConnectorResourceItem],
+    ) -> Connector:
+        """Select resources to sync (replaces the current set), activate the
+        connector, and trigger the backfill."""
+        data, _, _ = await self._client._request(
+            "PUT", f"/connectors/{connector_id}/resources", json=_selection_body(resources)
+        )
+        return Connector.from_dict(data)
+
+    async def sync(self, connector_id: str) -> Connector:
+        """Trigger an immediate sync. 409 unless the connector is ``active``."""
+        data, _, _ = await self._client._request("POST", f"/connectors/{connector_id}/sync")
+        return Connector.from_dict(data)
+
+    async def delete(self, connector_id: str) -> None:
+        """Disconnect and revoke the connector's stored credentials."""
+        await self._client._request("DELETE", f"/connectors/{connector_id}")

--- a/sdks/python/memsy/control_resources/connectors.py
+++ b/sdks/python/memsy/control_resources/connectors.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import time
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 from memsy.exceptions import MemsyAPIError
 from memsy.models import (
@@ -62,6 +63,17 @@ def requires_org_admin(provider: str) -> bool:
     enforces this and is authoritative for providers this SDK doesn't know.
     """
     return provider not in USER_SCOPED_PROVIDERS
+
+
+def _seg(value: str) -> str:
+    """Percent-encode a caller-supplied value as one opaque URL path segment.
+
+    ``safe=""`` so ``/``, ``..``, ``?`` and ``#`` can't be smuggled in to
+    resolve outside ``/connectors/`` — matches ``encodeURIComponent`` in the
+    Node SDK.
+    """
+    return quote(str(value), safe="")
+
 
 
 def _selection_body(
@@ -126,7 +138,7 @@ class ConnectorsResource:
         Member-safe — use this instead of :meth:`list` when the caller may not
         be an org admin.
         """
-        data, _, _ = self._client._request("GET", f"/connectors/{provider}/status")
+        data, _, _ = self._client._request("GET", f"/connectors/{_seg(provider)}/status")
         return ConnectorStatus.from_dict(data)
 
     # -- connecting ----------------------------------------------------------
@@ -146,7 +158,7 @@ class ConnectorsResource:
             :meth:`configure_s3`), 403 if an org-scoped provider is being
             connected by a non-admin, 409 if a workspace is already connected.
         """
-        data, _, _ = self._client._request("POST", f"/connectors/{provider}/connect")
+        data, _, _ = self._client._request("POST", f"/connectors/{_seg(provider)}/connect")
         return ConnectorConnection.from_dict(data)
 
     def configure_s3(
@@ -188,7 +200,7 @@ class ConnectorsResource:
 
     def get(self, connector_id: str) -> Connector:
         """Retrieve a single connector."""
-        data, _, _ = self._client._request("GET", f"/connectors/{connector_id}")
+        data, _, _ = self._client._request("GET", f"/connectors/{_seg(connector_id)}")
         return Connector.from_dict(data)
 
     def list_resources(
@@ -204,7 +216,7 @@ class ConnectorsResource:
         """
         params = {"parent_id": parent_id} if parent_id is not None else None
         data, _, _ = self._client._request(
-            "GET", f"/connectors/{connector_id}/resources", params=params
+            "GET", f"/connectors/{_seg(connector_id)}/resources", params=params
         )
         return [ConnectorResourceItem.from_dict(r) for r in data.get("resources", [])]
 
@@ -216,7 +228,7 @@ class ConnectorsResource:
         over every branch. 400 on providers without branch support.
         """
         data, _, _ = self._client._request(
-            "GET", f"/connectors/{connector_id}/branches", params={"repo": repo}
+            "GET", f"/connectors/{_seg(connector_id)}/branches", params={"repo": repo}
         )
         return [ConnectorResourceItem.from_dict(r) for r in data.get("resources", [])]
 
@@ -224,7 +236,7 @@ class ConnectorsResource:
         """Google Drive only: mint a short-lived token + config for the browser
         Google Picker. Owner-only — an admin cannot mint one for someone else.
         """
-        data, _, _ = self._client._request("GET", f"/connectors/{connector_id}/picker-token")
+        data, _, _ = self._client._request("GET", f"/connectors/{_seg(connector_id)}/picker-token")
         return PickerConfig.from_dict(data)
 
     def wait_until_authorized(
@@ -274,18 +286,18 @@ class ConnectorsResource:
         Org-scoped connectors: admins / API keys only. User-scoped: owner only.
         """
         data, _, _ = self._client._request(
-            "PUT", f"/connectors/{connector_id}/resources", json=_selection_body(resources)
+            "PUT", f"/connectors/{_seg(connector_id)}/resources", json=_selection_body(resources)
         )
         return Connector.from_dict(data)
 
     def sync(self, connector_id: str) -> Connector:
         """Trigger an immediate sync. 409 unless the connector is ``active``."""
-        data, _, _ = self._client._request("POST", f"/connectors/{connector_id}/sync")
+        data, _, _ = self._client._request("POST", f"/connectors/{_seg(connector_id)}/sync")
         return Connector.from_dict(data)
 
     def delete(self, connector_id: str) -> None:
         """Disconnect and revoke the connector's stored credentials."""
-        self._client._request("DELETE", f"/connectors/{connector_id}")
+        self._client._request("DELETE", f"/connectors/{_seg(connector_id)}")
 
 
 class AsyncConnectorsResource:
@@ -307,7 +319,7 @@ class AsyncConnectorsResource:
 
     async def status(self, provider: str) -> ConnectorStatus:
         """Whether a live connection exists for ``provider`` (member-safe)."""
-        data, _, _ = await self._client._request("GET", f"/connectors/{provider}/status")
+        data, _, _ = await self._client._request("GET", f"/connectors/{_seg(provider)}/status")
         return ConnectorStatus.from_dict(data)
 
     # -- connecting ----------------------------------------------------------
@@ -318,7 +330,7 @@ class AsyncConnectorsResource:
         Org-scoped providers (Slack, Notion, GitHub) require an org admin or an
         API key. S3 doesn't use OAuth — call :meth:`configure_s3`.
         """
-        data, _, _ = await self._client._request("POST", f"/connectors/{provider}/connect")
+        data, _, _ = await self._client._request("POST", f"/connectors/{_seg(provider)}/connect")
         return ConnectorConnection.from_dict(data)
 
     async def configure_s3(
@@ -350,7 +362,7 @@ class AsyncConnectorsResource:
 
     async def get(self, connector_id: str) -> Connector:
         """Retrieve a single connector."""
-        data, _, _ = await self._client._request("GET", f"/connectors/{connector_id}")
+        data, _, _ = await self._client._request("GET", f"/connectors/{_seg(connector_id)}")
         return Connector.from_dict(data)
 
     async def list_resources(
@@ -363,20 +375,22 @@ class AsyncConnectorsResource:
         """
         params = {"parent_id": parent_id} if parent_id is not None else None
         data, _, _ = await self._client._request(
-            "GET", f"/connectors/{connector_id}/resources", params=params
+            "GET", f"/connectors/{_seg(connector_id)}/resources", params=params
         )
         return [ConnectorResourceItem.from_dict(r) for r in data.get("resources", [])]
 
     async def list_branches(self, connector_id: str, repo: str) -> list[ConnectorResourceItem]:
         """GitHub only: list branches for one repo."""
         data, _, _ = await self._client._request(
-            "GET", f"/connectors/{connector_id}/branches", params={"repo": repo}
+            "GET", f"/connectors/{_seg(connector_id)}/branches", params={"repo": repo}
         )
         return [ConnectorResourceItem.from_dict(r) for r in data.get("resources", [])]
 
     async def picker_config(self, connector_id: str) -> PickerConfig:
         """Google Drive only: mint a short-lived token for the browser Picker."""
-        data, _, _ = await self._client._request("GET", f"/connectors/{connector_id}/picker-token")
+        data, _, _ = await self._client._request(
+            "GET", f"/connectors/{_seg(connector_id)}/picker-token"
+        )
         return PickerConfig.from_dict(data)
 
     async def wait_until_authorized(
@@ -413,15 +427,15 @@ class AsyncConnectorsResource:
         """Select resources to sync (replaces the current set), activate the
         connector, and trigger the backfill."""
         data, _, _ = await self._client._request(
-            "PUT", f"/connectors/{connector_id}/resources", json=_selection_body(resources)
+            "PUT", f"/connectors/{_seg(connector_id)}/resources", json=_selection_body(resources)
         )
         return Connector.from_dict(data)
 
     async def sync(self, connector_id: str) -> Connector:
         """Trigger an immediate sync. 409 unless the connector is ``active``."""
-        data, _, _ = await self._client._request("POST", f"/connectors/{connector_id}/sync")
+        data, _, _ = await self._client._request("POST", f"/connectors/{_seg(connector_id)}/sync")
         return Connector.from_dict(data)
 
     async def delete(self, connector_id: str) -> None:
         """Disconnect and revoke the connector's stored credentials."""
-        await self._client._request("DELETE", f"/connectors/{connector_id}")
+        await self._client._request("DELETE", f"/connectors/{_seg(connector_id)}")

--- a/sdks/python/memsy/models.py
+++ b/sdks/python/memsy/models.py
@@ -793,3 +793,165 @@ class ProInterestResponse:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ProInterestResponse:
         return cls(message=data["message"])
+
+
+# ============== Connectors (control-plane) ==============
+
+
+@dataclass
+class ConnectorConnection:
+    """Response from initiating a connector OAuth flow.
+
+    Send the end user to ``authorize_url``; once they complete the provider's
+    consent screen the provider redirects to Memsy's own callback, which
+    attaches the token server-side. Poll
+    :meth:`~memsy.control_resources.connectors.ConnectorsResource.get` (or
+    ``wait_until_authorized``) until the connector leaves ``pending``.
+    """
+
+    connector_id: str
+    authorize_url: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConnectorConnection:
+        return cls(connector_id=data["connector_id"], authorize_url=data["authorize_url"])
+
+
+@dataclass
+class Connector:
+    """A connected data source (Slack, Google Drive, S3, Notion, GitHub, OneDrive)."""
+
+    id: str
+    provider: str
+    status: str
+    display_name: str | None
+    external_account_id: str | None
+    configured_by_email: str | None
+    scopes: list[str]
+    last_sync_at: str | None
+    next_sync_at: str | None
+    last_error: str | None
+    created_at: str
+    # S3-only: the connected bucket + region. None for every other provider.
+    bucket: str | None = None
+    region: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Connector:
+        return cls(
+            id=data["id"],
+            provider=data["provider"],
+            status=data["status"],
+            display_name=data.get("display_name"),
+            external_account_id=data.get("external_account_id"),
+            configured_by_email=data.get("configured_by_email"),
+            scopes=data.get("scopes") or [],
+            last_sync_at=data.get("last_sync_at"),
+            next_sync_at=data.get("next_sync_at"),
+            last_error=data.get("last_error"),
+            created_at=data["created_at"],
+            bucket=data.get("bucket"),
+            region=data.get("region"),
+        )
+
+
+@dataclass
+class ConnectorResourceItem:
+    """A resource available on a connector, with its current selection state.
+
+    ``resource_type`` is provider-specific: ``channel`` (Slack), ``bucket``
+    (S3), ``workspace`` (Notion), ``repo`` / ``branch`` / ``default_branch``
+    (GitHub), ``folder`` / ``file`` (OneDrive, Google Drive).
+    """
+
+    external_id: str
+    resource_type: str
+    name: str | None
+    selected: bool
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConnectorResourceItem:
+        return cls(
+            external_id=data["external_id"],
+            resource_type=data.get("resource_type", "channel"),
+            name=data.get("name"),
+            selected=bool(data.get("selected", False)),
+        )
+
+
+@dataclass
+class ResourceSelection:
+    """A resource to enable syncing for, passed to ``configure_resources``.
+
+    ``resource_type`` must match what the provider expects — see
+    :class:`ConnectorResourceItem`. When you build selections from
+    ``list_resources()`` output, carry each item's ``resource_type`` through
+    unchanged rather than relying on the default.
+    """
+
+    external_id: str
+    resource_type: str = "channel"
+    name: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"external_id": self.external_id, "resource_type": self.resource_type}
+        if self.name is not None:
+            d["name"] = self.name
+        return d
+
+    @classmethod
+    def from_item(cls, item: ConnectorResourceItem) -> ResourceSelection:
+        """Build a selection from a listed resource, preserving its type."""
+        return cls(
+            external_id=item.external_id,
+            resource_type=item.resource_type,
+            name=item.name,
+        )
+
+
+@dataclass
+class ConnectorStatus:
+    """Whether the caller's org (or, for user-scoped providers, the caller)
+    has a live connection for a provider.
+
+    Member-safe: any seated caller may read this, unlike ``connectors.list()``.
+    """
+
+    connected: bool
+    display_name: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConnectorStatus:
+        return cls(
+            connected=bool(data.get("connected", False)),
+            display_name=data.get("display_name"),
+        )
+
+
+@dataclass
+class PickerConfig:
+    """Google Drive only: a short-lived access token + config for opening the
+    Google Picker in a browser.
+
+    Drive cannot enumerate files server-side (the app only ever sees files the
+    user explicitly grants), so ``list_resources()`` returns just the already
+    selected files. Real selection happens in the browser Picker; the chosen
+    file ids are then passed to ``configure_resources()``.
+
+    ``access_token`` is a live Google credential — never log it or hand it to
+    anything but the Picker.
+    """
+
+    access_token: str
+    expires_in: int
+    api_key: str
+    app_id: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PickerConfig:
+        return cls(
+            access_token=data["access_token"],
+            expires_in=int(data["expires_in"]),
+            api_key=data["api_key"],
+            app_id=data["app_id"],
+        )

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memsy"
-version = "0.3.2"
+version = "0.3.3"
 description = "Official Python SDK for the Memsy memory service"
 requires-python = ">=3.10"
 authors = [

--- a/sdks/python/tests/test_control_client.py
+++ b/sdks/python/tests/test_control_client.py
@@ -413,6 +413,20 @@ class TestConnectorsResource:
         mock_request.return_value = _make_response(204, None)
         assert client.connectors.delete("conn_1") is None
 
+    @patch("httpx.Client.request")
+    def test_path_segments_are_url_encoded(self, mock_request, client):
+        """A caller-supplied id can't escape /connectors/ via path characters."""
+        mock_request.return_value = _make_response(200, _CONNECTOR)
+        client.connectors.get("../../billing/invoices")
+        assert mock_request.call_args[0] == (
+            "GET",
+            "/connectors/..%2F..%2Fbilling%2Finvoices",
+        )
+
+        mock_request.return_value = _make_response(200, {"connected": False})
+        client.connectors.status("slack?x=1#y")
+        assert mock_request.call_args[0] == ("GET", "/connectors/slack%3Fx%3D1%23y/status")
+
     @patch("memsy.control_resources.connectors.time.sleep")
     @patch("httpx.Client.request")
     def test_wait_until_authorized_polls_through_409(self, mock_request, mock_sleep, client):

--- a/sdks/python/tests/test_control_client.py
+++ b/sdks/python/tests/test_control_client.py
@@ -1,4 +1,5 @@
 """Tests for MemsyControlClient and its sub-resources."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
@@ -6,8 +7,12 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from memsy import MemsyControlClient
-from memsy.exceptions import AuthenticationError, MemsyConnectionError
+from memsy import ConnectorResourceItem, MemsyControlClient, requires_org_admin
+from memsy.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    MemsyConnectionError,
+)
 
 
 def _make_response(status_code: int, body: object, headers: dict | None = None) -> MagicMock:
@@ -40,6 +45,7 @@ class TestControlClientInit:
         assert hasattr(client, "keys")
         assert hasattr(client, "events")
         assert hasattr(client, "interest")
+        assert hasattr(client, "connectors")
 
 
 class TestControlClientMe:
@@ -264,9 +270,7 @@ class TestInterestResource:
 
 class TestControlClientContextManager:
     def test_context_manager_closes_client(self):
-        with MemsyControlClient(
-            base_url="https://api.test.memsy.io", api_key="test_key"
-        ) as c:
+        with MemsyControlClient(base_url="https://api.test.memsy.io", api_key="test_key") as c:
             assert c._client is not None
 
 
@@ -275,3 +279,185 @@ class TestControlClientConnectionError:
     def test_connection_error(self, mock_request, client):
         with pytest.raises(MemsyConnectionError):
             client.me()
+
+
+_CONNECTOR = {
+    "id": "conn_1",
+    "provider": "slack",
+    "status": "active",
+    "display_name": "acme-workspace",
+    "external_account_id": "T123",
+    "configured_by_email": "admin@acme.com",
+    "scopes": ["channels:read"],
+    "last_sync_at": None,
+    "next_sync_at": None,
+    "last_error": None,
+    "created_at": "2026-04-01T00:00:00Z",
+}
+
+
+class TestConnectorsResource:
+    @patch("httpx.Client.request")
+    def test_create(self, mock_request, client):
+        mock_request.return_value = _make_response(
+            200,
+            {"connector_id": "conn_1", "authorize_url": "https://slack.com/oauth/v2/authorize?x=1"},
+        )
+        connection = client.connectors.create("slack")
+        assert connection.connector_id == "conn_1"
+        assert connection.authorize_url.startswith("https://slack.com")
+        assert mock_request.call_args[0] == ("POST", "/connectors/slack/connect")
+
+    @patch("httpx.Client.request")
+    def test_list(self, mock_request, client):
+        mock_request.return_value = _make_response(200, [_CONNECTOR])
+        connectors = client.connectors.list()
+        assert len(connectors) == 1
+        assert connectors[0].provider == "slack"
+        assert connectors[0].status == "active"
+
+    @patch("httpx.Client.request")
+    def test_list_providers(self, mock_request, client):
+        mock_request.return_value = _make_response(
+            200, {"providers": ["slack", "google_drive", "s3", "notion", "github", "onedrive"]}
+        )
+        assert "onedrive" in client.connectors.list_providers()
+
+    @patch("httpx.Client.request")
+    def test_status(self, mock_request, client):
+        mock_request.return_value = _make_response(
+            200, {"connected": True, "display_name": "acme-workspace"}
+        )
+        status = client.connectors.status("slack")
+        assert status.connected is True
+        assert status.display_name == "acme-workspace"
+
+    @patch("httpx.Client.request")
+    def test_list_resources(self, mock_request, client):
+        mock_request.return_value = _make_response(
+            200,
+            {
+                "resources": [
+                    {
+                        "external_id": "C123",
+                        "resource_type": "channel",
+                        "name": "general",
+                        "selected": False,
+                    }
+                ]
+            },
+        )
+        resources = client.connectors.list_resources("conn_1")
+        assert resources[0].external_id == "C123"
+        assert resources[0].selected is False
+        assert mock_request.call_args.kwargs["params"] is None
+
+    @patch("httpx.Client.request")
+    def test_list_resources_drilldown_passes_parent_id(self, mock_request, client):
+        mock_request.return_value = _make_response(200, {"resources": []})
+        client.connectors.list_resources("conn_1", parent_id="folder_9")
+        assert mock_request.call_args.kwargs["params"] == {"parent_id": "folder_9"}
+
+    @patch("httpx.Client.request")
+    def test_list_branches(self, mock_request, client):
+        mock_request.return_value = _make_response(
+            200,
+            {
+                "resources": [
+                    {
+                        "external_id": "acme/app#main",
+                        "resource_type": "default_branch",
+                        "name": "main",
+                        "selected": True,
+                    }
+                ]
+            },
+        )
+        branches = client.connectors.list_branches("conn_1", repo="acme/app")
+        assert branches[0].resource_type == "default_branch"
+        assert mock_request.call_args.kwargs["params"] == {"repo": "acme/app"}
+
+    @patch("httpx.Client.request")
+    def test_configure_resources_preserves_resource_type(self, mock_request, client):
+        mock_request.return_value = _make_response(200, _CONNECTOR)
+        items = [
+            ConnectorResourceItem(
+                external_id="b1", resource_type="folder", name="Docs", selected=False
+            )
+        ]
+        connector = client.connectors.configure_resources("conn_1", items)
+        assert connector.id == "conn_1"
+        assert mock_request.call_args.kwargs["json"] == {
+            "resources": [{"external_id": "b1", "resource_type": "folder", "name": "Docs"}]
+        }
+
+    @patch("httpx.Client.request")
+    def test_configure_s3(self, mock_request, client):
+        mock_request.return_value = _make_response(
+            200, {**_CONNECTOR, "provider": "s3", "bucket": "my-bucket", "region": "us-east-1"}
+        )
+        connector = client.connectors.configure_s3(
+            access_key_id="AKIA...",
+            secret_access_key="secret",
+            region="us-east-1",
+            bucket="my-bucket",
+        )
+        assert connector.bucket == "my-bucket"
+        assert connector.region == "us-east-1"
+        assert "connector_id" not in mock_request.call_args.kwargs["json"]
+
+    @patch("httpx.Client.request")
+    def test_sync_and_delete(self, mock_request, client):
+        mock_request.return_value = _make_response(200, _CONNECTOR)
+        assert client.connectors.sync("conn_1").id == "conn_1"
+        mock_request.return_value = _make_response(204, None)
+        assert client.connectors.delete("conn_1") is None
+
+    @patch("memsy.control_resources.connectors.time.sleep")
+    @patch("httpx.Client.request")
+    def test_wait_until_authorized_polls_through_409(self, mock_request, mock_sleep, client):
+        mock_request.side_effect = [
+            _make_response(409, {"detail": "Connector not authorized yet"}),
+            _make_response(
+                200,
+                {
+                    "resources": [
+                        {
+                            "external_id": "C1",
+                            "resource_type": "channel",
+                            "name": "general",
+                            "selected": False,
+                        }
+                    ]
+                },
+            ),
+        ]
+        resources = client.connectors.wait_until_authorized("conn_1", poll_interval=0.01)
+        assert len(resources) == 1
+        assert mock_sleep.called
+
+    @patch("memsy.control_resources.connectors.time.sleep")
+    @patch("httpx.Client.request")
+    def test_wait_until_authorized_times_out(self, mock_request, mock_sleep, client):
+        mock_request.return_value = _make_response(409, {"detail": "not authorized"})
+        with pytest.raises(TimeoutError):
+            client.connectors.wait_until_authorized("conn_1", timeout=0.02, poll_interval=0.01)
+
+    @patch("httpx.Client.request")
+    def test_wait_until_authorized_reraises_other_errors(self, mock_request, client):
+        mock_request.return_value = _make_response(403, {"detail": "Only an org admin can manage"})
+        with pytest.raises(AuthorizationError):
+            client.connectors.wait_until_authorized("conn_1", poll_interval=0.01)
+
+
+class TestProviderScoping:
+    def test_org_scoped_providers_require_admin(self):
+        for provider in ("slack", "s3", "notion", "github"):
+            assert requires_org_admin(provider) is True
+
+    def test_user_scoped_providers_do_not(self):
+        for provider in ("google_drive", "onedrive"):
+            assert requires_org_admin(provider) is False
+
+    def test_unknown_provider_defaults_to_admin_required(self):
+        assert requires_org_admin("some_future_provider") is True

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -210,7 +210,7 @@ wheels = [
 
 [[package]]
 name = "memsy"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

1. Adds connector management to both SDKs, so applications can connect a user's knowledge
sources. [ Slack, Google Drive, S3, Notion, GitHub, OneDrive ]
programmatically instead of sending someone to the Memsy console.

2. The `/connectors/*` endpoints already exist on the control plane and already accept
Bearer API-key auth. 
This PR is SDK surface only. The resource sits alongside `keys`, `billing`, `usage`, and `events`
on `MemsyControlClient`, follows same conventions.

3. Both packages go to **0.3.3**. The change is purely additive. No breaking changes, and
nothing to migrate.

## Motivation

Memsy can ingest and search memory through `MemsyClient` today, but the sources that
*feed* it could only be connected through the console. That's a hard stop for any
product embedding Memsy as its memory layer: onboarding a workspace meant leaving the
product. This closes that gap for every supported provider.

## Usage

Connectors live on the control plane, so they hang off `MemsyControlClient` — a
different base URL from the hot-path `MemsyClient`, same API key.

**Python**

```python
from memsy import MemsyControlClient, ResourceSelection

control = MemsyControlClient(
    base_url=MEMSY_CONTROL_URL,
    api_key=MEMSY_API_KEY,
)

# 1. Begin OAuth and send the end user to the consent screen.
connection = control.connectors.create("slack")
print(connection.authorize_url)

# 2. The provider redirects to Memsy's callback, which attaches the token.
#    Resource listing answers 409 until then, so poll.
resources = control.connectors.wait_until_authorized(
    connection.connector_id
)

# 3. Choose what to sync. This activates the connector and starts the backfill.
control.connectors.configure_resources(
    connection.connector_id,
    [
        ResourceSelection.from_item(r)
        for r in resources
        if r.name in {"general", "eng"}
    ],
)
```

**Node**

```node
import { MemsyControlClient } from "@memsy-io/memsy";

const control = new MemsyControlClient({ baseUrl, apiKey });

const connection = await control.connectors.create("slack");
const resources = await control.connectors.waitUntilAuthorized(
  connection.connectorId
);

await control.connectors.configureResources(
  connection.connectorId,
  resources
);
```

## API surface

```python
control.connectors.list_providers()
control.connectors.status(provider)                      # member-safe: connected? no ids
control.connectors.create(provider)                      # -> {connector_id, authorize_url}
control.connectors.configure_s3(access_key_id=..., secret_access_key=...,
                                region=..., bucket=...)  # S3 has no OAuth step
control.connectors.list() / .get(connector_id)
control.connectors.list_resources(connector_id, parent_id=None)
control.connectors.list_branches(connector_id, repo=...) # GitHub, lazy per repo
control.connectors.picker_config(connector_id)           # Google Drive browser Picker
control.connectors.wait_until_authorized(connector_id)   # polls through the 409s
control.connectors.configure_resources(connector_id, resources)
control.connectors.sync(connector_id) / .delete(connector_id)